### PR TITLE
feat: add bilingual redesign of portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# alexander-kosyak
+# Alexander Kosyak Portfolio
+
+A redesigned static portfolio preserving information from the original site. It presents bilingual content (English and Russian) for the Art Paris Project, biography, and contact details. The site is fully static and relies only on HTML, CSS, and a touch of vanilla JavaScript for smooth scrolling, language switching, and dynamic footer year.
+
+## Development
+
+Open `index.html` in a modern browser to view the site. No build step is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Art Project – Alexander Kosyak</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo"><a href="#home">Alexander Kosyak</a></h1>
+      <nav class="nav">
+        <a href="#about"><span class="lang-en">About</span><span class="lang-ru">Обо мне</span></a>
+        <a href="#projects"><span class="lang-en">Projects</span><span class="lang-ru">Проекты</span></a>
+        <a href="#contact"><span class="lang-en">Contact</span><span class="lang-ru">Контакты</span></a>
+      </nav>
+      <select id="lang-toggle" aria-label="Language selector">
+        <option value="en">EN</option>
+        <option value="ru">RU</option>
+      </select>
+    </div>
+  </header>
+
+  <main id="home" class="hero">
+    <div class="container">
+      <h2 class="lang-en">Art Paris Project</h2>
+      <h2 class="lang-ru">Проект Art Paris</h2>
+      <p class="lang-en">A notebook of works and ideas by Alexander Kosyak.</p>
+      <p class="lang-ru">Дневник работ и идей Александра Косяка.</p>
+    </div>
+  </main>
+
+  <section id="about" class="section">
+    <div class="container">
+      <h3 class="lang-en">About</h3>
+      <h3 class="lang-ru">Обо мне</h3>
+      <p class="lang-en">Alexander Kosyak is a visual artist working between Russia and France. His practice spans painting, digital media, and site‑specific installations exploring the pulse of contemporary cities.</p>
+      <p class="lang-ru">Художник Александр Косяк работает между Россией и Францией. В своей практике он соединяет живопись, цифровые медиа и site‑specific инсталляции, исследующие ритм современного города.</p>
+    </div>
+  </section>
+
+  <section id="projects" class="section alt">
+    <div class="container">
+      <h3 class="lang-en">Projects</h3>
+      <h3 class="lang-ru">Проекты</h3>
+      <ul class="project-list">
+        <li>
+          <h4 class="lang-en">Art Paris Project</h4>
+          <h4 class="lang-ru">Проект Art Paris</h4>
+          <p class="lang-en">Series of installations mapping personal narratives onto the streets of Paris.</p>
+          <p class="lang-ru">Серия инсталляций, накладывающих личные истории на улицы Парижа.</p>
+        </li>
+        <li>
+          <h4 class="lang-en">Sketchbook Series</h4>
+          <h4 class="lang-ru">Серия «Скетчбук»</h4>
+          <p class="lang-en">Daily drawing exercise capturing fleeting urban moments.</p>
+          <p class="lang-ru">Ежедневная практика зарисовок, фиксирующая мимолётные городские моменты.</p>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <section id="contact" class="section">
+    <div class="container">
+      <h3 class="lang-en">Contact</h3>
+      <h3 class="lang-ru">Контакты</h3>
+      <p class="lang-en">Reach out for collaborations or exhibition inquiries.</p>
+      <p class="lang-ru">Свяжитесь для сотрудничества или вопросов о выставках.</p>
+      <a class="button" href="mailto:hello@alexanderkosyak.com">
+        <span class="lang-en">Email Me</span>
+        <span class="lang-ru">Написать</span>
+      </a>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <small class="lang-en">&copy; <span id="year"></span> Alexander Kosyak. All rights reserved.</small>
+      <small class="lang-ru">&copy; <span id="year"></span> Александр Косяк. Все права защищены.</small>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,26 @@
+// Smooth scrolling for internal links
+const links = document.querySelectorAll('a[href^="#"]');
+links.forEach(link => {
+  link.addEventListener('click', e => {
+    const target = document.querySelector(link.getAttribute('href'));
+    if (target) {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+});
+
+// Language toggle
+const langToggle = document.getElementById('lang-toggle');
+if (langToggle) {
+  langToggle.value = document.documentElement.lang;
+  langToggle.addEventListener('change', e => {
+    document.documentElement.lang = e.target.value;
+  });
+}
+
+// Set current year in footer
+const yearSpan = document.getElementById('year');
+if (yearSpan) {
+  yearSpan.textContent = new Date().getFullYear();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,129 @@
+:root {
+  --bg: #f9f9f9;
+  --text: #222;
+  --primary: #4a6cf7;
+  --secondary: #f5f5f5;
+  --font-body: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.site-header {
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid #eaeaea;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+}
+
+.logo a {
+  text-decoration: none;
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.nav a {
+  margin-left: 1.5rem;
+  text-decoration: none;
+  color: var(--text);
+  font-weight: 400;
+}
+
+#lang-toggle {
+  margin-left: 1rem;
+  padding: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  min-height: 60vh;
+  text-align: center;
+}
+
+.hero h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.section.alt {
+  background: var(--secondary);
+}
+
+.project-list {
+  list-style: none;
+  display: grid;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--primary);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background 0.3s ease;
+}
+
+.button:hover {
+  background: #3b55c5;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem 0;
+  background: var(--secondary);
+  font-size: 0.875rem;
+}
+
+.lang-ru { display: none; }
+html[lang="ru"] .lang-en { display: none; }
+html[lang="ru"] .lang-ru { display: initial; }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+    --text: #e5e5e5;
+    --secondary: #2a2a2a;
+  }
+
+  .site-header {
+    border-bottom-color: #333;
+  }
+}


### PR DESCRIPTION
## Summary
- preserve original portfolio information with English and Russian content
- style layout with flex header and language selector
- add JavaScript for language toggle and dynamic footer year

## Testing
- `python3 -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0fd6d408328ad723158a97b85d7