### PR TITLE
Add manual language selection without Google Translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Static website showcasing the biography and work of artist Alexander Kosyak. The site is built with plain HTML5 and modern CSS.
 
+## Language support
+
+English text is the default. A selector in the top-right corner lets visitors switch to Russian, German or French, each with manually curated text.
+
 ## View locally
 
 Open `index.html` in a browser; no build step is required.

--- a/index.html
+++ b/index.html
@@ -10,90 +10,375 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header>
-    <h1>Alexander Kosyak</h1>
-    <p class="tagline">Artist</p>
-  </header>
-  <main>
-    <section id="bio">
-      <h2>Biography</h2>
-      <p>Born 08.12.1957, Russia.</p>
-      <p>1970 – 1974 School of Arts, Pyatigorsk city.</p>
-      <p>1979 – 1984 Moscow State University of Design and Technology, Faculty of Arts.</p>
-      <p>Since 1985 has been taking part in exhibitions, since 1987 began to participate in foreign exhibitions.</p>
-      <p>Since 1991 member of Moscow Artists Union, member of Russian Artists Union.</p>
-    </section>
-    <section id="events">
-      <h2>Exhibitions &amp; Residencies</h2>
-      <ul>
-        <li>2024 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
-        <li>2023 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
-        <li>2022 – exhibition "Open Art Posa", Kloster Posa, Zeitz, Germany.</li>
-        <li>2022 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
-        <li>2022 – exhibition "Programm für........", Atelierhaus, Zeitz, Germany.</li>
-        <li>2019 – resident of “Cité internationale des arts”, Paris, France (projects “Remembering the seventies”, “Je suis social”).</li>
-        <li>2018 – participant of the festival “Les Traversées du Marais” (project “Sinai stars”).</li>
-        <li>2018 – resident of “Cité internationale des arts”, Paris, France (projects “La Danse”, “The Endlove”).</li>
-        <li>2014 – solo exhibition “Why does it exist?”, residence “Nauart” Barcelona, Spain.</li>
-        <li>2014 – resident of “Nauart” Barcelona, Spain.</li>
-        <li>2014 – exhibition “Four Positions of Contemporary Painting”, gallery “Art Place Berlin”, Berlin, Germany.</li>
-        <li>2014 – medal for merit in creative activities, Moscow Artists Union.</li>
-        <li>2013 – solo exhibition, gallery “Na Kashirke”, Moscow, Russia.</li>
-        <li>2012 – solo exhibition, museum “Tsaritsino”, Moscow, Russia.</li>
-        <li>2010 – exhibition, gallery “Smend”, Cologne, Germany.</li>
-        <li>2009 – solo exhibition, gallery “Etienne Dewulf”, Gent, Belgium.</li>
-        <li>2008 – exhibition, gallery “CART”, Moscow, Russia.</li>
-        <li>2005 – solo exhibition “Ambiguous situation”, gallery "Kusnetskiy most", Moscow, Russia.</li>
-        <li>1998 – "in absentia - in corpore" exhibition, gallery "Zamek Ksiaz", Walbrzych, Poland.</li>
-        <li>1997 – exhibition, gallery “Tretyakov gallery”, Moscow, Russia.</li>
-        <li>1993 – exhibition, gallery “Habiart”, Deli, India.</li>
-        <li>1992 – biennale “Deuxien”, Belgium.</li>
-        <li>1991 – exhibition, gallery “David Harrington”, London, England.</li>
-        <li>1990 – exhibition, gallery “F-15”, Moss, Norway.</li>
-      </ul>
-    </section>
-    <section id="collections">
-      <h2>Collections</h2>
-      <ul>
-        <li>Moscow museum of modern art</li>
-        <li>“Bank of America” collection</li>
-        <li>Tsaritsyno Museum, Moscow</li>
-        <li>Walbrzych museum, Poland</li>
-        <li>Russian Decorative Art Museum, Moscow</li>
-      </ul>
-    </section>
-    <section id="teaching">
-      <h2>Teaching Position</h2>
-      <p>1997–1999 Moscow State University of Design and Technology, assistant professor, composition on Faculty of Arts.</p>
-    </section>
-    <section id="trips">
-      <h2>Creative Trips</h2>
-      <ul>
-        <li>2022 – Egypt, Cairo</li>
-        <li>2020 – Israel, Jerusalem</li>
-        <li>2019 – Greece, Athens</li>
-        <li>2018 – Egypt, Port Said, Ismailia, Luxor</li>
-        <li>2017 – Italia, Venezia</li>
-        <li>2016 – Italia, Roma, Firenze, Milano</li>
-        <li>2015 – Germany, Berlin</li>
-        <li>2014 – France, Paris</li>
-        <li>2013 – Myanmar, Bagan</li>
-        <li>2012 – India, Humpy</li>
-        <li>2009 – Holland, Amsterdam</li>
-        <li>2008 – Spain, Madrid</li>
-        <li>1998 – Poland, Wroclav</li>
-        <li>1993 – India, Himalaya</li>
-        <li>1992 – India, Himalaya</li>
-      </ul>
-    </section>
-    <section id="contact">
-      <h2>Contact</h2>
-      <p><a href="mailto:alexander-kosyak-art@yandex.ru">alexander-kosyak-art@yandex.ru</a></p>
-      <p><a href="tel:+79032388355">+7&nbsp;903&nbsp;238&nbsp;8355</a></p>
-    </section>
-  </main>
-  <footer>
-    <p>©2020 Alexander Kosyak.</p>
-  </footer>
+  <select id="language-selector">
+    <option value="en">English</option>
+    <option value="ru">Русский</option>
+    <option value="de">Deutsch</option>
+    <option value="fr">Français</option>
+  </select>
+
+  <div class="lang en">
+    <header>
+      <h1>Alexander Kosyak</h1>
+      <p class="tagline">Artist</p>
+    </header>
+    <main>
+      <section>
+        <h2>Biography</h2>
+        <p>Born 08.12.1957, Russia.</p>
+        <p>1970 – 1974 School of Arts, Pyatigorsk city.</p>
+        <p>1979 – 1984 Moscow State University of Design and Technology, Faculty of Arts.</p>
+        <p>Since 1985 has been taking part in exhibitions, since 1987 began to participate in foreign exhibitions.</p>
+        <p>Since 1991 member of Moscow Artists Union, member of Russian Artists Union.</p>
+      </section>
+      <section>
+        <h2>Exhibitions &amp; Residencies</h2>
+        <ul>
+          <li>2024 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
+          <li>2023 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
+          <li>2022 – exhibition "Open Art Posa", Kloster Posa, Zeitz, Germany.</li>
+          <li>2022 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
+          <li>2022 – exhibition "Programm für........", Atelierhaus, Zeitz, Germany.</li>
+          <li>2019 – resident of “Cité internationale des arts”, Paris, France (projects “Remembering the seventies”, “Je suis social”).</li>
+          <li>2018 – participant of the festival “Les Traversées du Marais” (project “Sinai stars”).</li>
+          <li>2018 – resident of “Cité internationale des arts”, Paris, France (projects “La Danse”, “The Endlove”).</li>
+          <li>2014 – solo exhibition “Why does it exist?”, residence “Nauart” Barcelona, Spain.</li>
+          <li>2014 – resident of “Nauart” Barcelona, Spain.</li>
+          <li>2014 – exhibition “Four Positions of Contemporary Painting”, gallery “Art Place Berlin”, Berlin, Germany.</li>
+          <li>2014 – medal for merit in creative activities, Moscow Artists Union.</li>
+          <li>2013 – solo exhibition, gallery “Na Kashirke”, Moscow, Russia.</li>
+          <li>2012 – solo exhibition, museum “Tsaritsino”, Moscow, Russia.</li>
+          <li>2010 – exhibition, gallery “Smend”, Cologne, Germany.</li>
+          <li>2009 – solo exhibition, gallery “Etienne Dewulf”, Gent, Belgium.</li>
+          <li>2008 – exhibition, gallery “CART”, Moscow, Russia.</li>
+          <li>2005 – solo exhibition “Ambiguous situation”, gallery "Kusnetskiy most", Moscow, Russia.</li>
+          <li>1998 – "in absentia - in corpore" exhibition, gallery "Zamek Ksiaz", Walbrzych, Poland.</li>
+          <li>1997 – exhibition, gallery “Tretyakov gallery”, Moscow, Russia.</li>
+          <li>1993 – exhibition, gallery “Habiart”, Deli, India.</li>
+          <li>1992 – biennale “Deuxien”, Belgium.</li>
+          <li>1991 – exhibition, gallery “David Harrington”, London, England.</li>
+          <li>1990 – exhibition, gallery “F-15”, Moss, Norway.</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Collections</h2>
+        <ul>
+          <li>Moscow museum of modern art</li>
+          <li>“Bank of America” collection</li>
+          <li>Tsaritsyno Museum, Moscow</li>
+          <li>Walbrzych museum, Poland</li>
+          <li>Russian Decorative Art Museum, Moscow</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Teaching Position</h2>
+        <p>1997–1999 Moscow State University of Design and Technology, assistant professor, composition on Faculty of Arts.</p>
+      </section>
+      <section>
+        <h2>Creative Trips</h2>
+        <ul>
+          <li>2022 – Egypt, Cairo</li>
+          <li>2020 – Israel, Jerusalem</li>
+          <li>2019 – Greece, Athens</li>
+          <li>2018 – Egypt, Port Said, Ismailia, Luxor</li>
+          <li>2017 – Italia, Venezia</li>
+          <li>2016 – Italia, Roma, Firenze, Milano</li>
+          <li>2015 – Germany, Berlin</li>
+          <li>2014 – France, Paris</li>
+          <li>2013 – Myanmar, Bagan</li>
+          <li>2012 – India, Humpy</li>
+          <li>2009 – Holland, Amsterdam</li>
+          <li>2008 – Spain, Madrid</li>
+          <li>1998 – Poland, Wroclav</li>
+          <li>1993 – India, Himalaya</li>
+          <li>1992 – India, Himalaya</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Contact</h2>
+        <p><a href="mailto:alexander-kosyak-art@yandex.ru">alexander-kosyak-art@yandex.ru</a></p>
+        <p><a href="tel:+79032388355">+7&nbsp;903&nbsp;238&nbsp;8355</a></p>
+      </section>
+    </main>
+    <footer>
+      <p>©2020 Alexander Kosyak.</p>
+    </footer>
+  </div>
+
+  <div class="lang ru">
+    <header>
+      <h1>Александр Косяк</h1>
+      <p class="tagline">Художник</p>
+    </header>
+    <main>
+      <section>
+        <h2>Биография</h2>
+        <p>Родился 08.12.1957, Россия.</p>
+        <p>1970–1974 Школа искусств, г. Пятигорск.</p>
+        <p>1979–1984 Московский государственный университет дизайна и технологии, факультет искусств.</p>
+        <p>С 1985 года участвует в выставках, с 1987 года начал участвовать в зарубежных выставках.</p>
+        <p>С 1991 года член Московского союза художников, член Союза художников России.</p>
+      </section>
+      <section>
+        <h2>Выставки и резиденции</h2>
+        <ul>
+          <li>2024 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
+          <li>2023 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
+          <li>2022 – выставка «Open Art Posa», Клостер Поза, Цайц, Германия.</li>
+          <li>2022 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
+          <li>2022 – выставка «Programm für........», Atelierhaus, Цайц, Германия.</li>
+          <li>2019 – резидент «Cité internationale des arts», Париж, Франция (проекты «Remembering the seventies», «Je suis social»).</li>
+          <li>2018 – участник фестиваля «Les Traversées du Marais» (проект «Sinai stars»).</li>
+          <li>2018 – резидент «Cité internationale des arts», Париж, Франция (проекты «La Danse», «The Endlove»).</li>
+          <li>2014 – персональная выставка «Why does it exist?», резиденция «Nauart», Барселона, Испания.</li>
+          <li>2014 – резидент «Nauart», Барселона, Испания.</li>
+          <li>2014 – выставка «Four Positions of Contemporary Painting», галерея «Art Place Berlin», Берлин, Германия.</li>
+          <li>2014 – медаль за заслуги в творческой деятельности, Московский союз художников.</li>
+          <li>2013 – персональная выставка, галерея «На Каширке», Москва, Россия.</li>
+          <li>2012 – персональная выставка, музей «Царицыно», Москва, Россия.</li>
+          <li>2010 – выставка, галерея «Smend», Кёльн, Германия.</li>
+          <li>2009 – персональная выставка, галерея «Etienne Dewulf», Гент, Бельгия.</li>
+          <li>2008 – выставка, галерея «CART», Москва, Россия.</li>
+          <li>2005 – персональная выставка «Ambiguous situation», галерея «Кузнецкий мост», Москва, Россия.</li>
+          <li>1998 – выставка «in absentia - in corpore», галерея «Zamek Ksiaz», Вальбжих, Польша.</li>
+          <li>1997 – выставка, галерея «Третьяковская галерея», Москва, Россия.</li>
+          <li>1993 – выставка, галерея «Habiart», Дели, Индия.</li>
+          <li>1992 – биеннале «Deuxien», Бельгия.</li>
+          <li>1991 – выставка, галерея «David Harrington», Лондон, Англия.</li>
+          <li>1990 – выставка, галерея «F-15», Мосс, Норвегия.</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Коллекции</h2>
+        <ul>
+          <li>Московский музей современного искусства</li>
+          <li>коллекция «Bank of America»</li>
+          <li>Музей «Царицыно», Москва</li>
+          <li>Музей Вальбжиха, Польша</li>
+          <li>Российский музей декоративного искусства, Москва</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Преподавательская деятельность</h2>
+        <p>1997–1999 Московский государственный университет дизайна и технологии, доцент, композиция на факультете искусств.</p>
+      </section>
+      <section>
+        <h2>Творческие поездки</h2>
+        <ul>
+          <li>2022 – Египет, Каир</li>
+          <li>2020 – Израиль, Иерусалим</li>
+          <li>2019 – Греция, Афины</li>
+          <li>2018 – Египет, Порт-Саид, Исмаилия, Луксор</li>
+          <li>2017 – Италия, Венеция</li>
+          <li>2016 – Италия, Рим, Флоренция, Милан</li>
+          <li>2015 – Германия, Берлин</li>
+          <li>2014 – Франция, Париж</li>
+          <li>2013 – Мьянма, Баган</li>
+          <li>2012 – Индия, Хампи</li>
+          <li>2009 – Голландия, Амстердам</li>
+          <li>2008 – Испания, Мадрид</li>
+          <li>1998 – Польша, Вроцлав</li>
+          <li>1993 – Индия, Гималаи</li>
+          <li>1992 – Индия, Гималаи</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Контакты</h2>
+        <p><a href="mailto:alexander-kosyak-art@yandex.ru">alexander-kosyak-art@yandex.ru</a></p>
+        <p><a href="tel:+79032388355">+7&nbsp;903&nbsp;238&nbsp;8355</a></p>
+      </section>
+    </main>
+    <footer>
+      <p>©2020 Александр Косяк.</p>
+    </footer>
+  </div>
+
+  <div class="lang de">
+    <header>
+      <h1>Alexander Kosyak</h1>
+      <p class="tagline">Künstler</p>
+    </header>
+    <main>
+      <section>
+        <h2>Biografie</h2>
+        <p>Geboren am 08.12.1957, Russland.</p>
+        <p>1970–1974 Kunstschule, Stadt Pjatigorsk.</p>
+        <p>1979–1984 Moskauer Staatliche Universität für Design und Technologie, Fakultät für Kunst.</p>
+        <p>Seit 1985 Teilnahme an Ausstellungen, seit 1987 Teilnahme an Ausstellungen im Ausland.</p>
+        <p>Seit 1991 Mitglied des Moskauer Künstlerverbands, Mitglied des Künstlerverbands Russlands.</p>
+      </section>
+      <section>
+        <h2>Ausstellungen &amp; Residenzen</h2>
+        <ul>
+          <li>2024 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.</li>
+          <li>2023 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.</li>
+          <li>2022 – Ausstellung „Open Art Posa“, Kloster Posa, Zeitz, Deutschland.</li>
+          <li>2022 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.</li>
+          <li>2022 – Ausstellung „Programm für........“, Atelierhaus, Zeitz, Deutschland.</li>
+          <li>2019 – Resident der „Cité internationale des arts“, Paris, Frankreich (Projekte „Remembering the seventies“, „Je suis social“).</li>
+          <li>2018 – Teilnehmer des Festivals „Les Traversées du Marais“ (Projekt „Sinai stars“).</li>
+          <li>2018 – Resident der „Cité internationale des arts“, Paris, Frankreich (Projekte „La Danse“, „The Endlove“).</li>
+          <li>2014 – Einzelausstellung „Why does it exist?“, Residenz „Nauart“, Barcelona, Spanien.</li>
+          <li>2014 – Resident der „Nauart“, Barcelona, Spanien.</li>
+          <li>2014 – Ausstellung „Four Positions of Contemporary Painting“, Galerie „Art Place Berlin“, Berlin, Deutschland.</li>
+          <li>2014 – Medaille für Verdienste in der kreativen Tätigkeit, Moskauer Künstlerverband.</li>
+          <li>2013 – Einzelausstellung, Galerie „Na Kashirke“, Moskau, Russland.</li>
+          <li>2012 – Einzelausstellung, Museum „Tsaritsino“, Moskau, Russland.</li>
+          <li>2010 – Ausstellung, Galerie „Smend“, Köln, Deutschland.</li>
+          <li>2009 – Einzelausstellung, Galerie „Etienne Dewulf“, Gent, Belgien.</li>
+          <li>2008 – Ausstellung, Galerie „CART“, Moskau, Russland.</li>
+          <li>2005 – Einzelausstellung „Ambiguous situation“, Galerie „Kusnetskiy most“, Moskau, Russland.</li>
+          <li>1998 – Ausstellung „in absentia - in corpore“, Galerie „Zamek Ksiaz“, Walbrzych, Polen.</li>
+          <li>1997 – Ausstellung, Galerie „Tretyakov gallery“, Moskau, Russland.</li>
+          <li>1993 – Ausstellung, Galerie „Habiart“, Delhi, Indien.</li>
+          <li>1992 – Biennale „Deuxien“, Belgien.</li>
+          <li>1991 – Ausstellung, Galerie „David Harrington“, London, England.</li>
+          <li>1990 – Ausstellung, Galerie „F-15“, Moss, Norwegen.</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Sammlungen</h2>
+        <ul>
+          <li>Museum für moderne Kunst Moskau</li>
+          <li>Sammlung „Bank of America“</li>
+          <li>Museum Tsaritsyno, Moskau</li>
+          <li>Museum Walbrzych, Polen</li>
+          <li>Russisches Museum für dekorative Kunst, Moskau</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Lehrtätigkeit</h2>
+        <p>1997–1999 Staatliche Universität für Design und Technologie Moskau, Assistenzprofessor, Komposition an der Fakultät für Kunst.</p>
+      </section>
+      <section>
+        <h2>Kreativreisen</h2>
+        <ul>
+          <li>2022 – Ägypten, Kairo</li>
+          <li>2020 – Israel, Jerusalem</li>
+          <li>2019 – Griechenland, Athen</li>
+          <li>2018 – Ägypten, Port Said, Ismailia, Luxor</li>
+          <li>2017 – Italien, Venedig</li>
+          <li>2016 – Italien, Rom, Florenz, Mailand</li>
+          <li>2015 – Deutschland, Berlin</li>
+          <li>2014 – Frankreich, Paris</li>
+          <li>2013 – Myanmar, Bagan</li>
+          <li>2012 – Indien, Hampi</li>
+          <li>2009 – Niederlande, Amsterdam</li>
+          <li>2008 – Spanien, Madrid</li>
+          <li>1998 – Polen, Wroclaw</li>
+          <li>1993 – Indien, Himalaya</li>
+          <li>1992 – Indien, Himalaya</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Kontakt</h2>
+        <p><a href="mailto:alexander-kosyak-art@yandex.ru">alexander-kosyak-art@yandex.ru</a></p>
+        <p><a href="tel:+79032388355">+7&nbsp;903&nbsp;238&nbsp;8355</a></p>
+      </section>
+    </main>
+    <footer>
+      <p>©2020 Alexander Kosyak.</p>
+    </footer>
+  </div>
+
+  <div class="lang fr">
+    <header>
+      <h1>Alexander Kosyak</h1>
+      <p class="tagline">Artiste</p>
+    </header>
+    <main>
+      <section>
+        <h2>Biographie</h2>
+        <p>Né le 08.12.1957, Russie.</p>
+        <p>1970–1974 École des arts, ville de Piatigorsk.</p>
+        <p>1979–1984 Université d'État de design et de technologie de Moscou, faculté des arts.</p>
+        <p>Depuis 1985 participe à des expositions, depuis 1987 participe à des expositions à l'étranger.</p>
+        <p>Depuis 1991 membre de l'Union des artistes de Moscou, membre de l'Union des artistes de Russie.</p>
+      </section>
+      <section>
+        <h2>Expositions &amp; Résidences</h2>
+        <ul>
+          <li>2024 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.</li>
+          <li>2023 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.</li>
+          <li>2022 – exposition « Open Art Posa », Kloster Posa, Zeitz, Allemagne.</li>
+          <li>2022 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.</li>
+          <li>2022 – exposition « Programm für........ », Atelierhaus, Zeitz, Allemagne.</li>
+          <li>2019 – résident de la « Cité internationale des arts », Paris, France (projets « Remembering the seventies », « Je suis social »).</li>
+          <li>2018 – participant du festival « Les Traversées du Marais » (projet « Sinai stars »).</li>
+          <li>2018 – résident de la « Cité internationale des arts », Paris, France (projets « La Danse », « The Endlove »).</li>
+          <li>2014 – exposition personnelle « Why does it exist? », résidence « Nauart », Barcelone, Espagne.</li>
+          <li>2014 – résident de « Nauart », Barcelone, Espagne.</li>
+          <li>2014 – exposition « Four Positions of Contemporary Painting », galerie « Art Place Berlin », Berlin, Allemagne.</li>
+          <li>2014 – médaille pour mérite dans l'activité créative, Union des artistes de Moscou.</li>
+          <li>2013 – exposition personnelle, galerie « Na Kashirke », Moscou, Russie.</li>
+          <li>2012 – exposition personnelle, musée « Tsaritsino », Moscou, Russie.</li>
+          <li>2010 – exposition, galerie « Smend », Cologne, Allemagne.</li>
+          <li>2009 – exposition personnelle, galerie « Etienne Dewulf », Gand, Belgique.</li>
+          <li>2008 – exposition, galerie « CART », Moscou, Russie.</li>
+          <li>2005 – exposition personnelle « Ambiguous situation », galerie « Kouznetskiy most », Moscou, Russie.</li>
+          <li>1998 – exposition « in absentia - in corpore », galerie « Zamek Ksiaz », Walbrzych, Pologne.</li>
+          <li>1997 – exposition, galerie « Tretyakov gallery », Moscou, Russie.</li>
+          <li>1993 – exposition, galerie « Habiart », Delhi, Inde.</li>
+          <li>1992 – biennale « Deuxien », Belgique.</li>
+          <li>1991 – exposition, galerie « David Harrington », Londres, Angleterre.</li>
+          <li>1990 – exposition, galerie « F-15 », Moss, Norvège.</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Collections</h2>
+        <ul>
+          <li>Musée d'art moderne de Moscou</li>
+          <li>Collection « Bank of America »</li>
+          <li>Musée Tsaritsyno, Moscou</li>
+          <li>Musée de Walbrzych, Pologne</li>
+          <li>Musée d'art décoratif de Russie, Moscou</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Poste d'enseignement</h2>
+        <p>1997–1999 Université d'État de design et de technologie de Moscou, professeur adjoint, composition à la faculté des arts.</p>
+      </section>
+      <section>
+        <h2>Voyages créatifs</h2>
+        <ul>
+          <li>2022 – Égypte, Le Caire</li>
+          <li>2020 – Israël, Jérusalem</li>
+          <li>2019 – Grèce, Athènes</li>
+          <li>2018 – Égypte, Port-Saïd, Ismaïlia, Louxor</li>
+          <li>2017 – Italie, Venise</li>
+          <li>2016 – Italie, Rome, Florence, Milan</li>
+          <li>2015 – Allemagne, Berlin</li>
+          <li>2014 – France, Paris</li>
+          <li>2013 – Myanmar, Bagan</li>
+          <li>2012 – Inde, Hampi</li>
+          <li>2009 – Pays-Bas, Amsterdam</li>
+          <li>2008 – Espagne, Madrid</li>
+          <li>1998 – Pologne, Wroclaw</li>
+          <li>1993 – Inde, Himalaya</li>
+          <li>1992 – Inde, Himalaya</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Contact</h2>
+        <p><a href="mailto:alexander-kosyak-art@yandex.ru">alexander-kosyak-art@yandex.ru</a></p>
+        <p><a href="tel:+79032388355">+7&nbsp;903&nbsp;238&nbsp;8355</a></p>
+      </section>
+    </main>
+    <footer>
+      <p>©2020 Alexander Kosyak.</p>
+    </footer>
+  </div>
+
+  <script>
+    const selector = document.getElementById('language-selector');
+    const blocks = document.querySelectorAll('.lang');
+    function updateLanguage() {
+      blocks.forEach(block => {
+        block.style.display = block.classList.contains(selector.value) ? '' : 'none';
+      });
+    }
+    selector.addEventListener('change', updateLanguage);
+    updateLanguage();
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -75,3 +75,13 @@ a {
 a:hover {
   color: var(--accent-color);
 }
+
+.lang {
+  display: none;
+}
+
+#language-selector {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+}


### PR DESCRIPTION
## Summary
- duplicate site content in Russian, German, and French
- toggle languages with a dropdown and simple JS
- document manual multilingual support and style selector

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f174cfa48328ab94b27e84f9ad22