### PR TITLE
Fix hidden content after translation cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
     const blocks = document.querySelectorAll('.lang');
     function updateLanguage() {
       blocks.forEach(block => {
-        block.style.display = block.classList.contains(selector.value) ? '' : 'none';
+        block.style.display = block.classList.contains(selector.value) ? 'block' : 'none';
       });
     }
     selector.addEventListener('change', updateLanguage);


### PR DESCRIPTION
## Summary
- Ensure selected language block is displayed by setting `block` style in language selector script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1053333e8832891ebd79cc793896d