### PR TITLE
Rename university and add awards sections to multilingual site

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <h2>Biography</h2>
 <p>Born 08.12.1957, Russia.</p>
 <p>1970 – 1974 School of Arts, Pyatigorsk city.</p>
-<p>1979 – 1984 Moscow State University of Design and Technology, Faculty of Arts.</p>
+<p>1979 – 1984 Kosygin State University of Russia (Technologies. Design. Arts).</p>
 <p>Since 1985 has been taking part in exhibitions, since 1987 began to participate in foreign exhibitions.</p>
 <p>Since 1991 member of Moscow Artists Union, member of Russian Artists Union.</p>
 </section>
@@ -45,19 +45,25 @@
 <li>2014 – solo exhibition “Why does it exist?”, residence “Nauart” Barcelona, Spain.</li>
 <li>2014 – resident of “Nauart” Barcelona, Spain.</li>
 <li>2014 – exhibition “Four Positions of Contemporary Painting”, gallery “Art Place Berlin”, Berlin, Germany.</li>
-<li>2014 – medal for merit in creative activities, Moscow Artists Union.</li>
 <li>2013 – solo exhibition, gallery “Na Kashirke”, Moscow, Russia.</li>
 <li>2012 – solo exhibition, museum “Tsaritsyno”, Moscow, Russia.</li>
 <li>2010 – exhibition, gallery “Smend”, Cologne, Germany.</li>
 <li>2009 – solo exhibition, gallery “Etienne Dewulf”, Gent, Belgium.</li>
 <li>2008 – exhibition, gallery “CART”, Moscow, Russia.</li>
 <li>2005 – solo exhibition “Ambiguous situation”, gallery “Kuznetsky Most”, Moscow, Russia.</li>
-<li>1998 – "in absentia - in corpore" exhibition, gallery "Zamek Ksiaz", Walbrzych, Poland.</li>
+<li>1998 – exhibition “in absentia - in corpore”, gallery “Zamek Ksiaz”, Walbrzych, Poland.</li>
 <li>1997 – exhibition, Tretyakov Gallery, Moscow, Russia.</li>
 <li>1993 – exhibition, gallery “Habiart”, Deli, India.</li>
 <li>1992 – biennale “Deuxien”, Belgium.</li>
 <li>1991 – exhibition, gallery “David Harrington”, London, England.</li>
 <li>1990 – exhibition, gallery “F-15”, Moss, Norway.</li>
+</ul>
+</section>
+<section>
+<h2>Awards</h2>
+<ul>
+<li>2014 – medal for merit in creative activities, Moscow Artists Union.</li>
+<li>2007 – Diploma of the Russian Academy of Arts.</li>
 </ul>
 </section>
 <section>
@@ -72,7 +78,7 @@
 </section>
 <section>
 <h2>Teaching Position</h2>
-<p>1997–1999 Moscow State University of Design and Technology, assistant professor, composition on Faculty of Arts.</p>
+<p>1997–1999 Kosygin State University of Russia (Technologies. Design. Arts), assistant professor, composition.</p>
 </section>
 <section>
 <h2>Creative Trips</h2>
@@ -114,7 +120,7 @@
 <h2>Биография</h2>
 <p>Родился 08.12.1957, Россия.</p>
 <p>1970–1974 Школа искусств, г. Пятигорск.</p>
-<p>1979–1984 Московский государственный университет дизайна и технологии, факультет искусств.</p>
+<p>1979–1984 Российский государственный университет им. А.Н. Косыгина (Технологии. Дизайн. Искусство).</p>
 <p>С 1985 года участвует в выставках, с 1987 года начал участвовать в зарубежных выставках.</p>
 <p>С 1991 года член Московского союза художников, член Союза художников России.</p>
 </section>
@@ -132,19 +138,25 @@
 <li>2014 – персональная выставка «Why does it exist?», резиденция «Nauart», Барселона, Испания.</li>
 <li>2014 – резидент «Nauart», Барселона, Испания.</li>
 <li>2014 – выставка «Four Positions of Contemporary Painting», галерея «Art Place Berlin», Берлин, Германия.</li>
-<li>2014 – медаль за заслуги в творческой деятельности, Московский союз художников.</li>
 <li>2013 – персональная выставка, галерея «На Каширке», Москва, Россия.</li>
 <li>2012 – персональная выставка, музей «Царицыно», Москва, Россия.</li>
 <li>2010 – выставка, галерея «Smend», Кёльн, Германия.</li>
 <li>2009 – персональная выставка, галерея «Etienne Dewulf», Гент, Бельгия.</li>
 <li>2008 – выставка, галерея «CART», Москва, Россия.</li>
-<li>2005 – персональная выставка «Ambiguous situation», галерея «Кузнецкий мост», Москва, Россия.</li>
+<li>2005 – персональная выставка «Неоднозначная ситуация», галерея «Кузнецкий мост», Москва, Россия.</li>
 <li>1998 – выставка «in absentia - in corpore», галерея «Zamek Ksiaz», Вальбжих, Польша.</li>
 <li>1997 – выставка, галерея «Третьяковская галерея», Москва, Россия.</li>
 <li>1993 – выставка, галерея «Habiart», Дели, Индия.</li>
 <li>1992 – биеннале «Deuxien», Бельгия.</li>
 <li>1991 – выставка, галерея «David Harrington», Лондон, Англия.</li>
 <li>1990 – выставка, галерея «F-15», Мосс, Норвегия.</li>
+</ul>
+</section>
+<section>
+<h2>Награды</h2>
+<ul>
+<li>2014 – медаль Московского союза художников за заслуги в творческой деятельности.</li>
+<li>2007 – Диплом Российской Академии Художеств.</li>
 </ul>
 </section>
 <section>
@@ -159,7 +171,7 @@
 </section>
 <section>
 <h2>Преподавательская деятельность</h2>
-<p>1997–1999 Московский государственный университет дизайна и технологии, доцент, композиция на факультете искусств.</p>
+<p>1997–1999 Российский государственный университет им. А.Н. Косыгина (Технологии. Дизайн. Искусство), доцент, композиция.</p>
 </section>
 <section>
 <h2>Творческие поездки</h2>
@@ -201,7 +213,7 @@
 <h2>Biografie</h2>
 <p>Geboren am 08.12.1957, Russland.</p>
 <p>1970–1974 Kunstschule, Stadt Pjatigorsk.</p>
-<p>1979–1984 Moskauer Staatliche Universität für Design und Technologie, Fakultät für Kunst.</p>
+<p>1979–1984 Kosygin Staatliche Universität Russlands (Technologien. Design. Kunst).</p>
 <p>Seit 1985 Teilnahme an Ausstellungen, seit 1987 Teilnahme an Ausstellungen im Ausland.</p>
 <p>Seit 1991 Mitglied des Moskauer Künstlerverbands, Mitglied des Künstlerverbands Russlands.</p>
 </section>
@@ -219,7 +231,6 @@
 <li>2014 – Einzelausstellung „Why does it exist?“, Residenz „Nauart“, Barcelona, Spanien.</li>
 <li>2014 – Resident der „Nauart“, Barcelona, Spanien.</li>
 <li>2014 – Ausstellung „Four Positions of Contemporary Painting“, Galerie „Art Place Berlin“, Berlin, Deutschland.</li>
-<li>2014 – Medaille für Verdienste in der kreativen Tätigkeit, Moskauer Künstlerverband.</li>
 <li>2013 – Einzelausstellung, Galerie „Na Kashirke“, Moskau, Russland.</li>
 <li>2012 – Einzelausstellung, Museum „Tsaritsino“, Moskau, Russland.</li>
 <li>2010 – Ausstellung, Galerie „Smend“, Köln, Deutschland.</li>
@@ -235,6 +246,13 @@
 </ul>
 </section>
 <section>
+<h2>Auszeichnung</h2>
+<ul>
+<li>2014 – Medaille für Verdienste in der kreativen Tätigkeit, Moskauer Künstlerverband.</li>
+<li>2007 – Diplom der Russischen Akademie der Künste.</li>
+</ul>
+</section>
+<section>
 <h2>Sammlungen</h2>
 <ul>
 <li>Museum für moderne Kunst Moskau</li>
@@ -246,7 +264,7 @@
 </section>
 <section>
 <h2>Lehrtätigkeit</h2>
-<p>1997–1999 Staatliche Universität für Design und Technologie Moskau, Assistenzprofessor, Komposition an der Fakultät für Kunst.</p>
+<p>1997–1999 Kosygin Staatliche Universität Russlands (Technologien. Design. Kunst), Assistenzprofessor, Komposition.</p>
 </section>
 <section>
 <h2>Kreativreisen</h2>
@@ -288,7 +306,7 @@
 <h2>Biographie</h2>
 <p>Né le 08.12.1957, Russie.</p>
 <p>1970–1974 École des arts, ville de Piatigorsk.</p>
-<p>1979–1984 Université d'État de design et de technologie de Moscou, faculté des arts.</p>
+<p>1979–1984 Université d'État Kosyguine de Russie (Technologies. Design. Arts).</p>
 <p>Depuis 1985 participe à des expositions, depuis 1987 participe à des expositions à l'étranger.</p>
 <p>Depuis 1991 membre de l'Union des artistes de Moscou, membre de l'Union des artistes de Russie.</p>
 </section>
@@ -306,7 +324,6 @@
 <li>2014 – exposition personnelle « Why does it exist? », résidence « Nauart », Barcelone, Espagne.</li>
 <li>2014 – résident de « Nauart », Barcelone, Espagne.</li>
 <li>2014 – exposition « Four Positions of Contemporary Painting », galerie « Art Place Berlin », Berlin, Allemagne.</li>
-<li>2014 – médaille du mérite artistique, Union des artistes de Moscou.</li>
 <li>2013 – exposition personnelle, galerie « Na Kashirke », Moscou, Russie.</li>
 <li>2012 – exposition personnelle, musée « Tsaritsino », Moscou, Russie.</li>
 <li>2010 – exposition, galerie « Smend », Cologne, Allemagne.</li>
@@ -322,6 +339,13 @@
 </ul>
 </section>
 <section>
+<h2>Récompenses</h2>
+<ul>
+<li>2014 – médaille du mérite artistique, Union des artistes de Moscou.</li>
+<li>2007 – Diplôme de l’Académie des Arts de Russie.</li>
+</ul>
+</section>
+<section>
 <h2>Collections</h2>
 <ul>
 <li>Musée d'art moderne de Moscou</li>
@@ -333,7 +357,7 @@
 </section>
 <section>
 <h2>Poste d'enseignement</h2>
-<p>1997–1999 Université d'État de design et de technologie de Moscou, professeur adjoint, composition à la faculté des arts.</p>
+<p>1997–1999 Université d'État Kosyguine de Russie (Technologies. Design. Arts), professeur adjoint, composition.</p>
 </section>
 <section>
 <h2>Voyages créatifs</h2>


### PR DESCRIPTION
## Summary
- Rename Moscow State University references to Kosygin State University of Russia across all language sections.
- Add dedicated Awards sections with 2014 and 2007 honors translated into English, Russian, German, and French.
- Correct Russian exhibition title for 2005 and update 1998 exhibition entry.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a212bc4e588328aa98ffd2ccc0277c