### PR TITLE
feat: add dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 <option value="de">Deutsch</option>
 <option value="fr">Français</option>
 </select>
+<button id="theme-toggle">Dark Mode</button>
 <div class="lang en">
 <header>
 <h1>Alexander Kosyak</h1>
@@ -392,6 +393,7 @@
 <script>
     const selector = document.getElementById('language-selector');
     const blocks = document.querySelectorAll('.lang');
+    const themeToggle = document.getElementById('theme-toggle');
     function updateLanguage() {
       blocks.forEach(block => {
         block.style.display = block.classList.contains(selector.value) ? 'block' : 'none';
@@ -399,6 +401,15 @@
     }
     selector.addEventListener('change', updateLanguage);
     updateLanguage();
+
+    function updateThemeButton() {
+      themeToggle.textContent = document.body.classList.contains('dark-theme') ? 'Light Mode' : 'Dark Mode';
+    }
+    themeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark-theme');
+      updateThemeButton();
+    });
+    updateThemeButton();
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,8 @@
   --bg-color: #fdfdfd;
   --text-color: #222;
   --accent-color: #333;
+  --border-color: #eee;
+  --muted-color: #666;
 }
 
 * {
@@ -16,10 +18,18 @@ body {
   color: var(--text-color);
 }
 
+body.dark-theme {
+  --bg-color: #222;
+  --text-color: #fdfdfd;
+  --accent-color: #ddd;
+  --border-color: #444;
+  --muted-color: #aaa;
+}
+
 header {
   text-align: center;
   padding: 2rem 1rem 1rem;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 header h1 {
@@ -61,9 +71,9 @@ ul li {
 footer {
   text-align: center;
   padding: 1rem;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--border-color);
   font-size: 0.9rem;
-  color: #666;
+  color: var(--muted-color);
 }
 
 a {
@@ -84,4 +94,14 @@ a:hover {
   position: fixed;
   top: 1rem;
   right: 1rem;
+}
+
+#theme-toggle {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  padding: 0.25rem 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add dark theme CSS variables and styling
- include toggle button for dark/light mode
- implement JavaScript to switch themes and update button text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a221c5fd888328a659bc43aa8fc157