### PR TITLE
Refresh minimal site with modern UI touches

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
+<meta content="light dark" name="color-scheme"/>
 <title>Alexander Kosyak – Art Project</title>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
@@ -11,13 +12,15 @@
 <link href="style.css" rel="stylesheet"/>
 </head>
 <body>
-<select id="language-selector">
-<option value="en">English</option>
-<option value="ru">Русский</option>
-<option value="de">Deutsch</option>
-<option value="fr">Français</option>
-</select>
-<button id="theme-toggle">Dark Mode</button>
+<nav class="toolbar">
+  <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
+  <select id="language-selector" aria-label="Select language">
+    <option value="en">English</option>
+    <option value="ru">Русский</option>
+    <option value="de">Deutsch</option>
+    <option value="fr">Français</option>
+  </select>
+</nav>
 <div class="lang en">
 <header>
 <h1>Alexander Kosyak</h1>
@@ -394,6 +397,11 @@
     const selector = document.getElementById('language-selector');
     const blocks = document.querySelectorAll('.lang');
     const themeToggle = document.getElementById('theme-toggle');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+      document.body.classList.add('dark-theme');
+    }
     function updateLanguage() {
       blocks.forEach(block => {
         block.style.display = block.classList.contains(selector.value) ? 'block' : 'none';
@@ -406,7 +414,8 @@
       themeToggle.textContent = document.body.classList.contains('dark-theme') ? 'Light Mode' : 'Dark Mode';
     }
     themeToggle.addEventListener('click', () => {
-      document.body.classList.toggle('dark-theme');
+      const isDark = document.body.classList.toggle('dark-theme');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
       updateThemeButton();
     });
     updateThemeButton();

--- a/style.css
+++ b/style.css
@@ -4,18 +4,25 @@
   --accent-color: #333;
   --border-color: #eee;
   --muted-color: #666;
+  --radius: 0.25rem;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  color-scheme: light dark;
+}
+
 body {
   margin: 0;
   font-family: 'Montserrat', sans-serif;
   line-height: 1.6;
+  font-size: clamp(1rem, 0.9rem + 0.3vw, 1.1rem);
   background: var(--bg-color);
   color: var(--text-color);
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
 body.dark-theme {
@@ -90,18 +97,28 @@ a:hover {
   display: none;
 }
 
-#language-selector {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-}
-
-#theme-toggle {
+.toolbar {
   position: fixed;
   top: 1rem;
   left: 1rem;
+  right: 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+#language-selector,
+#theme-toggle {
+  font: inherit;
   background: var(--bg-color);
   color: var(--text-color);
   border: 1px solid var(--border-color);
+  border-radius: var(--radius);
   padding: 0.25rem 0.5rem;
+}
+
+#language-selector:focus-visible,
+#theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- add color-scheme metadata and toolbar housing theme & language controls
- support system theme preference with persistent toggle
- modernize base styling with responsive type and unified control styles

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes prettier -c index.html style.css` *(warn: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a225ad468883289c210fa4aaef96c3