### PR TITLE
feat: restructure intro with image gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,14 +37,25 @@
 <div id="lang-blocks">
   <div data-lang="en">
     <header>
-      <h1>Alexander Kosyak</h1>
-      <p class="tagline">Artist. Exhibitions since 1985. Member of Moscow Artists Union.</p>
-      <p class="cta-links">
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Email the artist</a>
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">General inquiries</a>
-      </p>
-      <img class="portrait" src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak in his studio" width="1280" height="960" loading="lazy"/>
-      <div class="highlights">Collections: MMOMA; Bank of America; Tsaritsyno · Residencies: Cité internationale des arts; Atelierhaus Zeitz · Awards: Moscow Artists Union medal; Russian Academy of Arts diploma.</div>
+      <div class="intro-grid">
+        <div class="intro-info">
+          <h1>Alexander Kosyak</h1>
+          <p class="tagline">Artist. Exhibitions since 1985. Member of Moscow Artists Union.</p>
+          <p class="cta-links">
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Email the artist</a>
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">General inquiries</a>
+          </p>
+          <div class="highlights">Collections: MMOMA; Bank of America; Tsaritsyno · Residencies: Cité internationale des arts; Atelierhaus Zeitz · Awards: Moscow Artists Union medal; Russian Academy of Arts diploma.</div>
+        </div>
+        <div class="intro-gallery">
+          <img src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak in his studio" loading="lazy"/>
+          <div class="row">
+            <img src="images/studio2.jpg" alt="Studio view" loading="lazy"/>
+            <img src="images/studio_photo_3.jpg" alt="Studio view" loading="lazy"/>
+          </div>
+          <img src="images/graphic_4.jpg" alt="Graphic artwork" loading="lazy"/>
+        </div>
+      </div>
     </header>
     <nav class="top-nav">
       <a href="#bio">Biography</a>
@@ -151,14 +162,25 @@
 
   <div data-lang="ru">
     <header>
-      <h1>Александр Косяк</h1>
-      <p class="tagline">Художник. Участник выставок с 1985 года. Член Московского союза художников.</p>
-      <p class="cta-links">
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Написать художнику</a>
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Общие вопросы</a>
-      </p>
-      <img class="portrait" src="images/kosyak_studio_photo.jpg" alt="Александр Косяк в своей студии" width="1280" height="960" loading="lazy"/>
-      <div class="highlights">Коллекции: ММОМА; Bank of America; Царицыно · Резиденции: Cité internationale des arts; Atelierhaus Zeitz · Награды: медаль Московского союза художников; диплом Российской академии художеств.</div>
+      <div class="intro-grid">
+        <div class="intro-info">
+          <h1>Александр Косяк</h1>
+          <p class="tagline">Художник. Участник выставок с 1985 года. Член Московского союза художников.</p>
+          <p class="cta-links">
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Написать художнику</a>
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Общие вопросы</a>
+          </p>
+          <div class="highlights">Коллекции: ММОМА; Bank of America; Царицыно · Резиденции: Cité internationale des arts; Atelierhaus Zeitz · Награды: медаль Московского союза художников; диплом Российской академии художеств.</div>
+        </div>
+        <div class="intro-gallery">
+          <img src="images/kosyak_studio_photo.jpg" alt="Александр Косяк в своей студии" loading="lazy"/>
+          <div class="row">
+            <img src="images/studio2.jpg" alt="Вид студии" loading="lazy"/>
+            <img src="images/studio_photo_3.jpg" alt="Ещё один вид студии" loading="lazy"/>
+          </div>
+          <img src="images/graphic_4.jpg" alt="Графическая работа" loading="lazy"/>
+        </div>
+      </div>
     </header>
     <nav class="top-nav">
       <a href="#bio">Биография</a>
@@ -265,14 +287,25 @@
 
   <div data-lang="de">
     <header>
-      <h1>Alexander Kosyak</h1>
-      <p class="tagline">Künstler. Ausstellungen seit 1985. Mitglied des Moskauer Künstlerverbands.</p>
-      <p class="cta-links">
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">E-Mail an den Künstler</a>
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Allgemeine Anfragen</a>
-      </p>
-      <img class="portrait" src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak in seinem Atelier" width="1280" height="960" loading="lazy"/>
-      <div class="highlights">Sammlungen: MMOMA; Bank of America; Tsaritsyno · Residenzen: Cité internationale des arts; Atelierhaus Zeitz · Auszeichnungen: Medaille des Moskauer Künstlerverbands; Diplom der Russischen Akademie der Künste.</div>
+      <div class="intro-grid">
+        <div class="intro-info">
+          <h1>Alexander Kosyak</h1>
+          <p class="tagline">Künstler. Ausstellungen seit 1985. Mitglied des Moskauer Künstlerverbands.</p>
+          <p class="cta-links">
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">E-Mail an den Künstler</a>
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Allgemeine Anfragen</a>
+          </p>
+          <div class="highlights">Sammlungen: MMOMA; Bank of America; Tsaritsyno · Residenzen: Cité internationale des arts; Atelierhaus Zeitz · Auszeichnungen: Medaille des Moskauer Künstlerverbands; Diplom der Russischen Akademie der Künste.</div>
+        </div>
+        <div class="intro-gallery">
+          <img src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak in seinem Atelier" loading="lazy"/>
+          <div class="row">
+            <img src="images/studio2.jpg" alt="Studioansicht" loading="lazy"/>
+            <img src="images/studio_photo_3.jpg" alt="Studioansicht 2" loading="lazy"/>
+          </div>
+          <img src="images/graphic_4.jpg" alt="Grafikarbeit" loading="lazy"/>
+        </div>
+      </div>
     </header>
     <nav class="top-nav">
       <a href="#bio">Biografie</a>
@@ -379,14 +412,25 @@
 
   <div data-lang="fr">
     <header>
-      <h1>Alexander Kosyak</h1>
-      <p class="tagline">Artiste. Expositions depuis 1985. Membre de l'Union des artistes de Moscou.</p>
-      <p class="cta-links">
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Contacter l'artiste</a>
-        <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Demandes générales</a>
-      </p>
-      <img class="portrait" src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak dans son atelier" width="1280" height="960" loading="lazy"/>
-      <div class="highlights">Collections : MMOMA ; Bank of America ; Tsaritsyno · Résidences : Cité internationale des arts ; Atelierhaus Zeitz · Récompenses : médaille de l'Union des artistes de Moscou ; diplôme de l'Académie russe des arts.</div>
+      <div class="intro-grid">
+        <div class="intro-info">
+          <h1>Alexander Kosyak</h1>
+          <p class="tagline">Artiste. Expositions depuis 1985. Membre de l'Union des artistes de Moscou.</p>
+          <p class="cta-links">
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Contacter l'artiste</a>
+            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Demandes générales</a>
+          </p>
+          <div class="highlights">Collections : MMOMA ; Bank of America ; Tsaritsyno · Résidences : Cité internationale des arts ; Atelierhaus Zeitz · Récompenses : médaille de l'Union des artistes de Moscou ; diplôme de l'Académie russe des arts.</div>
+        </div>
+        <div class="intro-gallery">
+          <img src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak dans son atelier" loading="lazy"/>
+          <div class="row">
+            <img src="images/studio2.jpg" alt="Vue de l'atelier" loading="lazy"/>
+            <img src="images/studio_photo_3.jpg" alt="Deuxième vue de l'atelier" loading="lazy"/>
+          </div>
+          <img src="images/graphic_4.jpg" alt="Œuvre graphique" loading="lazy"/>
+        </div>
+      </div>
     </header>
     <nav class="top-nav">
       <a href="#bio">Biographie</a>

--- a/style.css
+++ b/style.css
@@ -36,7 +36,6 @@ body.dark-theme {
 }
 
 header {
-  text-align: center;
   padding: 2rem 1rem 1rem;
   border-bottom: 1px solid var(--border-color);
 }
@@ -52,13 +51,34 @@ header h1 {
   margin-top: 0.5rem;
 }
 
-.portrait {
-  display: block;
-  max-width: 300px;
+.intro-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .intro-grid {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+
+.intro-gallery {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.intro-gallery img {
   width: 100%;
   height: auto;
-  margin: 1rem auto;
   border-radius: var(--radius);
+  display: block;
+}
+
+.intro-gallery .row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
 }
 
 main {


### PR DESCRIPTION
## Summary
- Split intro into two-column layout with key details on the left and image gallery on the right
- Add responsive gallery styles and remove old portrait styling

## Testing
- `npx --yes prettier -c index.html style.css` *(fails: Code style issues found in 2 files)*
- `tidy -qe index.html` *(warnings about duplicate anchors and loading attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68a7558ac23c832885dc7069409822a5