### PR TITLE
Stack index page images vertically

### DIFF
--- a/biography.html
+++ b/biography.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Biography, exhibitions, awards and collections of artist Alexander Kosyak."/>
   <meta property="og:title" content="Biography - Alexander Kosyak Art Studio"/>
   <meta property="og:description" content="Artist. Exhibitions since 1985. Member of Moscow Artists Union."/>
-  <meta property="og:image" content="images/kosyak_studio_photo.jpg"/>
+  <meta property="og:image" content="images/ak1.jpg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet"/>

--- a/contact.html
+++ b/contact.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Contact information for artist Alexander Kosyak."/>
   <meta property="og:title" content="Contact - Alexander Kosyak Art Studio"/>
   <meta property="og:description" content="Email and phone for Alexander Kosyak."/>
-  <meta property="og:image" content="images/kosyak_studio_photo.jpg"/>
+  <meta property="og:image" content="images/ak1.jpg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet"/>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Artist Alexander Kosyak. Exhibitions since 1985. Member of Moscow Artists Union."/>
   <meta property="og:title" content="Alexander Kosyak – Art Project"/>
   <meta property="og:description" content="Artist. Exhibitions since 1985. Member of Moscow Artists Union."/>
-  <meta property="og:image" content="images/kosyak_studio_photo.jpg"/>
+  <meta property="og:image" content="images/ak1.jpg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet"/>
@@ -32,10 +32,10 @@
     <a href="contact.html">Contact</a>
   </nav>
   <main class="gallery">
-    <img src="images/kosyak_studio_photo.jpg" alt="Alexander Kosyak in his studio"/>
-    <img src="images/studio2.jpg" alt="Studio view"/>
-    <img src="images/studio_photo_3.jpg" alt="Studio view"/>
-    <img src="images/graphic_4.jpg" alt="Graphic artwork"/>
+    <img src="images/ak1.jpg" alt="Alexander Kosyak in his studio"/>
+    <img src="images/ak2.jpg" alt="Studio view"/>
+    <img src="images/ak3.jpg" alt="Studio view"/>
+    <img src="images/ak4.jpg" alt="Graphic artwork"/>
   </main>
   <footer>
     <p>@ Alexanderkosyakartstudio. All rights reserved.</p>

--- a/last-works.html
+++ b/last-works.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Recent works by artist Alexander Kosyak."/>
   <meta property="og:title" content="Last Works - Alexander Kosyak Art Studio"/>
   <meta property="og:description" content="Recent works by Alexander Kosyak."/>
-  <meta property="og:image" content="images/kosyak_studio_photo.jpg"/>
+  <meta property="og:image" content="images/ak1.jpg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet"/>

--- a/style.css
+++ b/style.css
@@ -187,8 +187,8 @@ a:hover {
 }
 
 .gallery {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 0.5rem;
   padding: 2rem;
 }


### PR DESCRIPTION
## Summary
- Display index page gallery images in a vertical column for simpler viewing
- Update image file paths after renaming

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7930b78bc83289e368422581a5995