### PR TITLE
Fix biography header alignment and image layout

### DIFF
--- a/biography.html
+++ b/biography.html
@@ -459,7 +459,7 @@
   </div>
   </div>
   <footer>
-    <p>@ Alexanderkosyakartstudio. All rights reserved.</p>
+    <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
   </footer>
   <script>
     const langButtons = document.querySelectorAll('.lang-switcher button');

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,7 @@
     <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
   </main>
   <footer>
-    <p>@ Alexanderkosyakartstudio. All rights reserved.</p>
+    <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
   </footer>
   <script>
     const link = document.querySelector('.email');

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <img src="images/ak4.jpg" alt="Graphic artwork"/>
   </main>
   <footer>
-    <p>@ Alexanderkosyakartstudio. All rights reserved.</p>
+    <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
   </footer>
 </body>
 </html>

--- a/last-works.html
+++ b/last-works.html
@@ -30,7 +30,7 @@
     </ul>
   </main>
   <footer>
-    <p>@ Alexanderkosyakartstudio. All rights reserved.</p>
+    <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
   </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -54,13 +54,8 @@ header h1 {
 .intro-grid {
   display: grid;
   gap: 1rem;
-}
-
-@media (min-width: 600px) {
-  .intro-grid {
-    grid-template-columns: 1fr 1fr;
-    align-items: start;
-  }
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .intro-gallery {
@@ -77,7 +72,7 @@ header h1 {
 
 .intro-gallery .row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 0.5rem;
 }
 
@@ -187,10 +182,10 @@ a:hover {
 }
 
 .gallery {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 0.5rem;
-  padding: 2rem;
+  padding: 2rem 1rem;
 }
 
 .gallery img {


### PR DESCRIPTION
## Summary
- Center biography headers by constraining intro grid width
- Stack gallery images in a single column
- Restore natural copyright symbol across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a794db45e88328aa8e1395117bacf0