### PR TITLE
Add clickable artwork captions and refine biography intro

### DIFF
--- a/biography.html
+++ b/biography.html
@@ -1,494 +1,794 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="color-scheme" content="light dark"/>
-  <title>Biography - Alexander Kosyak Art Studio</title>
-  <meta name="description" content="Biography, exhibitions, awards and collections of artist Alexander Kosyak."/>
-  <meta property="og:title" content="Biography - Alexander Kosyak Art Studio"/>
-  <meta property="og:description" content="Artist. Exhibitions since 1985. Member of Moscow Artists Union."/>
-  <meta property="og:image" content="images/ak1.jpg"/>
-  <link rel="preconnect" href="https://fonts.googleapis.com"/>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="style.css"/>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    "name": "Alexander Kosyak",
-    "birthDate": "1957-12-08",
-    "memberOf": "Moscow Artists Union",
-    "award": "Russian Academy of Arts diploma"
-  }
-  </script>
-</head>
-<body>
-  <nav class="top-nav">
-    <a href="index.html">Home</a>
-    <a href="biography.html">Biography</a>
-    <a href="last-works.html">Last Works</a>
-    <a href="contact.html">Contact</a>
-  </nav>
-  <div class="lang-switcher" role="group" aria-label="Language switcher">
-    <button data-setlang="en">EN</button>
-    <button data-setlang="ru">RU</button>
-    <button data-setlang="de">DE</button>
-    <button data-setlang="fr">FR</button>
-  </div>
-  <div id="lang-blocks">
-  <div data-lang="en">
-    <header>
-      <div class="intro-grid">
-        <div class="intro-info">
-          <h1>Alexander Kosyak</h1>
-          <p class="tagline">Artist. Exhibitions since 1985. Member of Moscow Artists Union.</p>
-          <p class="cta-links">
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Email the artist</a>
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">General inquiries</a>
-          </p>
-          <div class="highlights">Collections: MMOMA; Bank of America; Tsaritsyno · Residencies: Cité internationale des arts; Atelierhaus Zeitz · Awards: Moscow Artists Union medal; Russian Academy of Arts diploma.</div>
-        </div>
-        </div>
-    </header>
-    <main>
-      <section>
-        <h2 id="bio">Biography</h2>
-        <p>Born 08.12.1957, Russia.</p>
-        <p>1970 – 1974 School of Arts, Pyatigorsk city.</p>
-        <p>1979 – 1984 Kosygin State University of Russia (Technologies. Design. Arts).</p>
-        <p>Since 1985 has been taking part in exhibitions, since 1987 began to participate in foreign exhibitions.</p>
-        <p>Since 1991 member of Moscow Artists Union, member of Russian Artists Union.</p>
-      </section>
-      <section>
-        <h2 id="exhibitions">Exhibitions &amp; Residencies</h2>
-        <ul>
-          <li>2024 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
-          <li>2023 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
-          <li>2022 – exhibition "Open Art Posa", Kloster Posa, Zeitz, Germany.</li>
-          <li>2022 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
-          <li>2022 – exhibition "Programm für…", Atelierhaus, Zeitz, Germany.</li>
-          <li>2019 – resident of “Cité internationale des arts”, Paris, France (projects “Remembering the seventies”, “Je suis social”).</li>
-          <li>2018 – participant of the festival “Les Traversées du Marais” (project “Sinai stars”).</li>
-          <li>2018 – resident of “Cité internationale des arts”, Paris, France (projects “La Danse”, “The Endlove”).</li>
-          <li>2014 – solo exhibition “Why does it exist?”, residence “Nauart” Barcelona, Spain.</li>
-          <li>2014 – resident of “Nauart” Barcelona, Spain.</li>
-          <li>2014 – exhibition “Four Positions of Contemporary Painting”, gallery “Art Place Berlin”, Berlin, Germany.</li>
-          <li>2013 – solo exhibition, gallery “Na Kashirke”, Moscow, Russia.</li>
-        </ul>
-        <details>
-          <summary>Earlier</summary>
-          <ul>
-            <li>2012 – solo exhibition, museum “Tsaritsyno”, Moscow, Russia.</li>
-            <li>2010 – exhibition, gallery “Smend”, Cologne, Germany.</li>
-            <li>2009 – solo exhibition, gallery “Etienne Dewulf”, Ghent, Belgium.</li>
-            <li>2008 – exhibition, gallery “CART”, Moscow, Russia.</li>
-            <li>2005 – solo exhibition “Ambiguous situation”, gallery “Kuznetsky Most”, Moscow, Russia.</li>
-            <li>1998 – exhibition “in absentia - in corpore”, gallery “Zamek Książ”, Wałbrzych, Poland.</li>
-            <li>1997 – exhibition, State Tretyakov Gallery, Moscow, Russia.</li>
-            <li>1993 – exhibition, gallery “Habiart”, Delhi, India.</li>
-            <li>1992 – biennale “Deuxième”, Belgium.</li>
-            <li>1991 – exhibition, gallery “David Harrington”, London, England.</li>
-            <li>1990 – exhibition, gallery “F-15”, Moss, Norway.</li>
-          </ul>
-        </details>
-      </section>
-      <section>
-        <h2 id="awards">Awards</h2>
-        <ul>
-          <li>2014 – medal for merit in creative activities, Moscow Artists Union.</li>
-          <li>2007 – Diploma of the Russian Academy of Arts.</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="collections">Collections</h2>
-        <ul>
-          <li>Moscow Museum of Modern Art</li>
-          <li>“Bank of America” collection</li>
-          <li>Tsaritsyno Museum, Moscow</li>
-          <li>Wałbrzych Museum, Poland</li>
-          <li>Russian Decorative Art Museum, Moscow</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="teaching">Teaching Position</h2>
-        <p>1997–1999 Kosygin State University of Russia (Technologies. Design. Arts), assistant professor, composition.</p>
-      </section>
-      <section>
-        <h2 id="trips">Creative Trips</h2>
-        <ul>
-          <li>2022 – Egypt, Cairo</li>
-          <li>2020 – Israel, Jerusalem</li>
-          <li>2019 – Greece, Athens</li>
-          <li>2018 – Egypt, Port Said, Ismailia, Luxor</li>
-          <li>2017 – Italy, Venice</li>
-          <li>2016 – Italy, Rome, Florence, Milan</li>
-          <li>2015 – Germany, Berlin</li>
-          <li>2014 – France, Paris</li>
-          <li>2013 – Myanmar, Bagan</li>
-          <li>2012 – India, Hampi</li>
-          <li>2009 – Holland, Amsterdam</li>
-          <li>2008 – Spain, Madrid</li>
-          <li>1998 – Poland, Wroclaw</li>
-          <li>1993 – India, the Himalayas</li>
-          <li>1992 – India, the Himalayas</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="contact">Contact</h2>
-        <p><a class="email" data-user="alexander-kosyak-art" data-domain="yandex.ru"></a> <button class="copy-email" type="button">Copy email</button></p>
-        <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
-      </section>
-    </main>
-  </div>
-
-  <div data-lang="ru">
-    <header>
-      <div class="intro-grid">
-        <div class="intro-info">
-          <h1>Александр Косяк</h1>
-          <p class="tagline">Художник. Участник выставок с 1985 года. Член Московского союза художников.</p>
-          <p class="cta-links">
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Написать художнику</a>
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Общие вопросы</a>
-          </p>
-          <div class="highlights">Коллекции: ММОМА; Bank of America; Царицыно · Резиденции: Cité internationale des arts; Atelierhaus Zeitz · Награды: медаль Московского союза художников; диплом Российской академии художеств.</div>
-        </div>
-        </div>
-    </header>
-    <main>
-      <section>
-        <h2 id="bio">Биография</h2>
-        <p>Родился 08.12.1957, Россия.</p>
-        <p>1970 – 1974 Школа искусств, г. Пятигорск.</p>
-        <p>1979 – 1984 Российский государственный университет им. А.Н. Косыгина (технологии, дизайн, искусство).</p>
-        <p>С 1985 года участвует в выставках, с 1987 года начал участвовать в зарубежных выставках.</p>
-        <p>С 1991 года член Московского союза художников, член Союза художников России.</p>
-      </section>
-      <section>
-        <h2 id="exhibitions">Выставки и резиденции</h2>
-        <ul>
-          <li>2024 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
-          <li>2023 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
-          <li>2022 – выставка «Open Art Posa», Kloster Posa, Цайц, Германия.</li>
-          <li>2022 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
-          <li>2022 – выставка «Programm für…», Atelierhaus, Цайц, Германия.</li>
-          <li>2019 – резидент «Cité internationale des arts», Париж, Франция (проекты «Remembering the seventies», «Je suis social»).</li>
-          <li>2018 – участник фестиваля «Les Traversées du Marais» (проект «Sinai stars»).</li>
-          <li>2018 – резидент «Cité internationale des arts», Париж, Франция (проекты «La Danse», «The Endlove»).</li>
-          <li>2014 – персональная выставка «Why does it exist?», резиденция «Nauart» Барселона, Испания.</li>
-          <li>2014 – резидент «Nauart» Барселона, Испания.</li>
-          <li>2014 – выставка «Four Positions of Contemporary Painting», галерея «Art Place Berlin», Берлин, Германия.</li>
-          <li>2013 – персональная выставка, галерея «На Каширке», Москва, Россия.</li>
-        </ul>
-        <details>
-          <summary>Ранее</summary>
-          <ul>
-            <li>2012 – персональная выставка, музей «Царицыно», Москва, Россия.</li>
-            <li>2010 – выставка, галерея «Smend», Кёльн, Германия.</li>
-            <li>2009 – персональная выставка, галерея «Etienne Dewulf», Гент, Бельгия.</li>
-            <li>2008 – выставка, галерея «CART», Москва, Россия.</li>
-            <li>2005 – персональная выставка «Ambiguous situation», галерея «Кузнецкий Мост», Москва, Россия.</li>
-            <li>1998 – выставка «in absentia - in corpore», галерея «Zamek Ksiaz», Вальбжих, Польша.</li>
-            <li>1997 – выставка, Государственная Третьяковская галерея, Москва, Россия.</li>
-            <li>1993 – выставка, галерея «Habiart», Дели, Индия.</li>
-            <li>1992 – биеннале «Deuxien», Бельгия.</li>
-            <li>1991 – выставка, галерея «David Harrington», Лондон, Англия.</li>
-            <li>1990 – выставка, галерея «F-15», Мосс, Норвегия.</li>
-          </ul>
-        </details>
-      </section>
-      <section>
-        <h2 id="awards">Награды</h2>
-        <ul>
-          <li>2014 – медаль за заслуги в творческой деятельности, Московский союз художников.</li>
-          <li>2007 – диплом Российской академии художеств.</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="collections">Коллекции</h2>
-        <ul>
-          <li>Московский музей современного искусства</li>
-          <li>Коллекция «Bank of America»</li>
-          <li>Музей «Царицыно», Москва</li>
-          <li>Музей Вальбжиха, Польша</li>
-          <li>Музей декоративного искусства, Москва</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="teaching">Преподавание</h2>
-        <p>1997–1999 Российский государственный университет им. А.Н. Косыгина (технологии, дизайн, искусство), ассистент-профессор, композиция.</p>
-      </section>
-      <section>
-        <h2 id="trips">Творческие поездки</h2>
-        <ul>
-          <li>2022 – Египет, Каир</li>
-          <li>2020 – Израиль, Иерусалим</li>
-          <li>2019 – Греция, Афины</li>
-          <li>2018 – Египет, Порт-Саид, Исмаилия, Луксор</li>
-          <li>2017 – Италия, Венеция</li>
-          <li>2016 – Италия, Рим, Флоренция, Милан</li>
-          <li>2015 – Германия, Берлин</li>
-          <li>2014 – Франция, Париж</li>
-          <li>2013 – Мьянма, Баган</li>
-          <li>2012 – Индия, Хампи</li>
-          <li>2009 – Голландия, Амстердам</li>
-          <li>2008 – Испания, Мадрид</li>
-          <li>1998 – Польша, Вроцлав</li>
-          <li>1993 – Индия, Гималаи</li>
-          <li>1992 – Индия, Гималаи</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="contact">Контакты</h2>
-        <p><a class="email" data-user="alexander-kosyak-art" data-domain="yandex.ru"></a> <button class="copy-email" type="button">Скопировать email</button></p>
-        <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
-      </section>
-    </main>
-  </div>
-
-  <div data-lang="de">
-    <header>
-      <div class="intro-grid">
-        <div class="intro-info">
-          <h1>Alexander Kosyak</h1>
-          <p class="tagline">Künstler. Ausstellungen seit 1985. Mitglied des Moskauer Künstlerverbands.</p>
-          <p class="cta-links">
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">E-Mail an den Künstler</a>
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Allgemeine Anfragen</a>
-          </p>
-          <div class="highlights">Sammlungen: MMOMA; Bank of America; Tsaritsyno · Residenzen: Cité internationale des arts; Atelierhaus Zeitz · Auszeichnungen: Medaille des Moskauer Künstlerverbands; Diplom der Russischen Akademie der Künste.</div>
-        </div>
-        </div>
-    </header>
-    <main>
-      <section>
-        <h2 id="bio">Biografie</h2>
-        <p>Geboren am 08.12.1957, Russland.</p>
-        <p>1970 – 1974 Kunstschule, Stadt Pjatigorsk.</p>
-        <p>1979 – 1984 Staatliche Technologische Universität Russlands namens A. N. Kosygin (Technologien. Design. Kunst).</p>
-        <p>Seit 1985 nimmt er an Ausstellungen teil, seit 1987 an Ausstellungen im Ausland.</p>
-        <p>Seit 1991 Mitglied des Moskauer Künstlerverbands, Mitglied des Künstlerverbands Russlands.</p>
-      </section>
-      <section>
-        <h2 id="exhibitions">Ausstellungen &amp; Residenzen</h2>
-        <ul>
-          <li>2024 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.</li>
-          <li>2023 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.</li>
-          <li>2022 – Ausstellung „Open Art Posa“, Kloster Posa, Zeitz, Deutschland.</li>
-          <li>2022 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.</li>
-          <li>2022 – Ausstellung „Programm für…“, Atelierhaus, Zeitz, Deutschland.</li>
-          <li>2019 – Resident der „Cité internationale des arts“, Paris, Frankreich (Projekte „Remembering the seventies“, „Je suis social“).</li>
-          <li>2018 – Teilnehmer des Festivals „Les Traversées du Marais“ (Projekt „Sinai stars“).</li>
-          <li>2018 – Resident der „Cité internationale des arts“, Paris, Frankreich (Projekte „La Danse“, „The Endlove“).</li>
-          <li>2014 – Einzelausstellung „Why does it exist?“, Residenz „Nauart“ Barcelona, Spanien.</li>
-          <li>2014 – Resident „Nauart“ Barcelona, Spanien.</li>
-          <li>2014 – Ausstellung „Four Positions of Contemporary Painting“, Galerie „Art Place Berlin“, Berlin, Deutschland.</li>
-          <li>2013 – Einzelausstellung, Galerie „Na Kashirke“, Moskau, Russland.</li>
-        </ul>
-        <details>
-          <summary>Früher</summary>
-          <ul>
-            <li>2012 – Einzelausstellung, Museum „Tsaritsyno“, Moskau, Russland.</li>
-            <li>2010 – Ausstellung, Galerie „Smend“, Köln, Deutschland.</li>
-            <li>2009 – Einzelausstellung, Galerie „Etienne Dewulf“, Gent, Belgien.</li>
-            <li>2008 – Ausstellung, Galerie „CART“, Moskau, Russland.</li>
-            <li>2005 – Einzelausstellung „Ambiguous situation“, Galerie „Kuznetsky Most“, Moskau, Russland.</li>
-            <li>1998 – Ausstellung „in absentia - in corpore“, Galerie „Zamek Książ“, Wałbrzych, Polen.</li>
-            <li>1997 – Ausstellung, Staatliche Tretjakow-Galerie, Moskau, Russland.</li>
-            <li>1993 – Ausstellung, Galerie „Habiart“, Delhi, Indien.</li>
-            <li>1992 – Biennale „Deuxième“, Belgien.</li>
-            <li>1991 – Ausstellung, Galerie „David Harrington“, London, England.</li>
-            <li>1990 – Ausstellung, Galerie „F-15“, Moss, Norwegen.</li>
-          </ul>
-        </details>
-      </section>
-      <section>
-        <h2 id="awards">Auszeichnungen</h2>
-        <ul>
-          <li>2014 – Medaille für Verdienste in der künstlerischen Tätigkeit, Moskauer Künstlerverband.</li>
-          <li>2007 – Diplom der Russischen Akademie der Künste.</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="collections">Sammlungen</h2>
-        <ul>
-          <li>Museum für zeitgenössische Kunst Moskau</li>
-          <li>Sammlung „Bank of America“</li>
-          <li>Museum „Tsaritsyno“, Moskau</li>
-          <li>Museum Wałbrzych, Polen</li>
-          <li>Russisches Museum für dekorative Kunst, Moskau</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="teaching">Lehrtätigkeit</h2>
-        <p>1997–1999 Staatliche Technologische Universität Russlands namens A. N. Kosygin (Technologien. Design. Kunst), Assistenzprofessor, Komposition.</p>
-      </section>
-      <section>
-        <h2 id="trips">Kreativreisen</h2>
-        <ul>
-          <li>2022 – Ägypten, Kairo</li>
-          <li>2020 – Israel, Jerusalem</li>
-          <li>2019 – Griechenland, Athen</li>
-          <li>2018 – Ägypten, Port Said, Ismailia, Luxor</li>
-          <li>2017 – Italien, Venedig</li>
-          <li>2016 – Italien, Rom, Florenz, Mailand</li>
-          <li>2015 – Deutschland, Berlin</li>
-          <li>2014 – Frankreich, Paris</li>
-          <li>2013 – Myanmar, Bagan</li>
-          <li>2012 – Indien, Hampi</li>
-          <li>2009 – Holland, Amsterdam</li>
-          <li>2008 – Spanien, Madrid</li>
-          <li>1998 – Polen, Wroclaw</li>
-          <li>1993 – Indien, Himalaya</li>
-          <li>1992 – Indien, Himalaya</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="contact">Kontakt</h2>
-        <p><a class="email" data-user="alexander-kosyak-art" data-domain="yandex.ru"></a> <button class="copy-email" type="button">E-Mail kopieren</button></p>
-        <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
-      </section>
-    </main>
-  </div>
-
-  <div data-lang="fr">
-    <header>
-      <div class="intro-grid">
-        <div class="intro-info">
-          <h1>Alexander Kosyak</h1>
-          <p class="tagline">Artiste. Expositions depuis 1985. Membre de l'Union des artistes de Moscou.</p>
-          <p class="cta-links">
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=Portfolio%20or%20Press%20request">Contacter l'artiste</a>
-            <a href="mailto:alexander-kosyak-art@yandex.ru?subject=General%20inquiry">Demandes générales</a>
-          </p>
-          <div class="highlights">Collections : MMOMA ; Bank of America ; Tsaritsyno · Résidences : Cité internationale des arts ; Atelierhaus Zeitz · Récompenses : médaille de l'Union des artistes de Moscou ; diplôme de l'Académie russe des arts.</div>
-        </div>
-        </div>
-    </header>
-    <main>
-      <section>
-        <h2 id="bio">Biographie</h2>
-        <p>Né le 08.12.1957, Russie.</p>
-        <p>1970–1974 École des arts, ville de Piatigorsk.</p>
-        <p>1979–1984 Université d'État Kosyguine de Russie (Technologies. Design. Arts).</p>
-        <p>Depuis 1985 participe à des expositions, depuis 1987 participe à des expositions à l'étranger.</p>
-        <p>Depuis 1991 membre de l'Union des artistes de Moscou, membre de l'Union des artistes de Russie.</p>
-      </section>
-      <section>
-        <h2 id="exhibitions">Expositions &amp; Résidences</h2>
-        <ul>
-          <li>2024 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.</li>
-          <li>2023 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.</li>
-          <li>2022 – exposition « Open Art Posa », Kloster Posa, Zeitz, Allemagne.</li>
-          <li>2022 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.</li>
-          <li>2022 – exposition « Programm für… », Atelierhaus, Zeitz, Allemagne.</li>
-          <li>2019 – résident de la « Cité internationale des arts », Paris, France (projets « Remembering the seventies », « Je suis social »).</li>
-          <li>2018 – participant du festival « Les Traversées du Marais » (projet « Sinai stars »).</li>
-          <li>2018 – résident de la « Cité internationale des arts », Paris, France (projets « La Danse », « The Endlove »).</li>
-          <li>2014 – exposition personnelle « Why does it exist? », résidence « Nauart », Barcelone, Espagne.</li>
-          <li>2014 – résident de « Nauart », Barcelone, Espagne.</li>
-          <li>2014 – exposition « Four Positions of Contemporary Painting », galerie « Art Place Berlin », Berlin, Allemagne.</li>
-          <li>2013 – exposition personnelle, galerie « Na Kashirke », Moscou, Russie.</li>
-        </ul>
-        <details>
-          <summary>Plus tôt</summary>
-          <ul>
-            <li>2012 – exposition personnelle, musée « Tsaritsino », Moscou, Russie.</li>
-            <li>2010 – exposition, galerie « Smend », Cologne, Allemagne.</li>
-            <li>2009 – exposition personnelle, galerie « Etienne Dewulf », Gand, Belgique.</li>
-            <li>2008 – exposition, galerie « CART », Moscou, Russie.</li>
-            <li>2005 – exposition personnelle « Ambiguous situation », galerie « Kuznetsky Most », Moscou, Russie.</li>
-            <li>1998 – exposition « in absentia - in corpore », galerie « Zamek Książ », Wałbrzych, Pologne.</li>
-            <li>1997 – exposition, Galerie d’État Tretiakov, Moscou, Russie.</li>
-            <li>1993 – exposition, galerie « Habiart », Delhi, Inde.</li>
-            <li>1992 – biennale « Deuxième », Belgique.</li>
-            <li>1991 – exposition, galerie « David Harrington », Londres, Angleterre.</li>
-            <li>1990 – exposition, galerie « F-15 », Moss, Norvège.</li>
-          </ul>
-        </details>
-      </section>
-      <section>
-        <h2 id="awards">Récompenses</h2>
-        <ul>
-          <li>2014 – médaille du mérite artistique, Union des artistes de Moscou.</li>
-          <li>2007 – Diplôme de l’Académie des Arts de Russie.</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="collections">Collections</h2>
-        <ul>
-          <li>Musée d'art moderne de Moscou</li>
-          <li>Collection « Bank of America »</li>
-          <li>Musée Tsaritsyno, Moscou</li>
-          <li>Musée de Wałbrzych, Pologne</li>
-          <li>Musée d'art décoratif de Russie, Moscou</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="teaching">Enseignement</h2>
-        <p>1997–1999 Université d'État Kosyguine de Russie (Technologies. Design. Arts), professeur adjoint, composition.</p>
-      </section>
-      <section>
-        <h2 id="trips">Voyages créatifs</h2>
-        <ul>
-          <li>2022 – Égypte, Le Caire</li>
-          <li>2020 – Israël, Jérusalem</li>
-          <li>2019 – Grèce, Athènes</li>
-          <li>2018 – Égypte, Port-Saïd, Ismaïlia, Louxor</li>
-          <li>2017 – Italie, Venise</li>
-          <li>2016 – Italie, Rome, Florence, Milan</li>
-          <li>2015 – Allemagne, Berlin</li>
-          <li>2014 – France, Paris</li>
-          <li>2013 – Myanmar, Bagan</li>
-          <li>2012 – Inde, Hampi</li>
-          <li>2009 – Pays-Bas, Amsterdam</li>
-          <li>2008 – Espagne, Madrid</li>
-          <li>1998 – Pologne, Wrocław</li>
-          <li>1993 – Inde, Himalaya</li>
-          <li>1992 – Inde, Himalaya</li>
-        </ul>
-      </section>
-      <section>
-        <h2 id="contact">Contact</h2>
-        <p><a class="email" data-user="alexander-kosyak-art" data-domain="yandex.ru"></a> <button class="copy-email" type="button">Copier l’email</button></p>
-        <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
-      </section>
-    </main>
-  </div>
-  </div>
-  <footer>
-    <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
-  </footer>
-  <script>
-    const langButtons = document.querySelectorAll('.lang-switcher button');
-    const blocks = document.querySelectorAll('[data-lang]');
-    const blocksContainer = document.getElementById('lang-blocks');
-    function showLang(lang) {
-      blocks.forEach(block => {
-        const show = block.dataset.lang === lang;
-        block.style.display = show ? 'block' : 'none';
-        if (show) blocksContainer.prepend(block);
-      });
-      document.documentElement.lang = lang;
-      localStorage.setItem('lang', lang);
-      langButtons.forEach(btn => btn.classList.toggle('active', btn.dataset.setlang === lang));
-    }
-    langButtons.forEach(btn => btn.addEventListener('click', () => showLang(btn.dataset.setlang)));
-    showLang(localStorage.getItem('lang') || 'en');
-
-    document.querySelectorAll('.email').forEach(link => {
-      const email = `${link.dataset.user}@${link.dataset.domain}`;
-      link.href = `mailto:${email}`;
-      link.textContent = email;
-      const btn = link.nextElementSibling;
-      if (btn && btn.classList.contains('copy-email')) {
-        btn.addEventListener('click', () => {
-          navigator.clipboard.writeText(email);
-        });
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Biography - Alexander Kosyak Art Studio</title>
+    <meta
+      name="description"
+      content="Biography, exhibitions, awards and collections of artist Alexander Kosyak."
+    />
+    <meta
+      property="og:title"
+      content="Biography - Alexander Kosyak Art Studio"
+    />
+    <meta
+      property="og:description"
+      content="Artist. Exhibitions since 1985. Member of Moscow Artists Union."
+    />
+    <meta property="og:image" content="images/ak1.jpg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Alexander Kosyak",
+        "birthDate": "1957-12-08",
+        "memberOf": "Moscow Artists Union",
+        "award": "Russian Academy of Arts diploma"
       }
-    });
-  </script>
-</body>
+    </script>
+  </head>
+  <body>
+    <nav class="top-nav">
+      <a href="index.html">Home</a>
+      <a href="biography.html">Biography</a>
+      <a href="last-works.html">Last Works</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <div class="lang-switcher" role="group" aria-label="Language switcher">
+      <button data-setlang="en">EN</button>
+      <button data-setlang="ru">RU</button>
+      <button data-setlang="de">DE</button>
+      <button data-setlang="fr">FR</button>
+    </div>
+    <div id="lang-blocks">
+      <div data-lang="en">
+        <header>
+          <div class="intro-grid">
+            <div class="intro-info">
+              <h1>Alexander Kosyak</h1>
+              <p>
+                Alexander Kosyak was born on December 8, 1957 in Russia. Artist,
+                exhibiting since 1985, member of the Moscow Artists Union.
+              </p>
+              <p>
+                Collections: MMOMA; Bank of America; Tsaritsyno · Residencies:
+                Cité internationale des arts; Atelierhaus Zeitz · Awards: Moscow
+                Artists Union medal; Russian Academy of Arts diploma.
+              </p>
+            </div>
+          </div>
+        </header>
+        <main>
+          <section>
+            <h2 id="bio">Biography</h2>
+            <p>Born 08.12.1957, Russia.</p>
+            <p>1970 – 1974 School of Arts, Pyatigorsk city.</p>
+            <p>
+              1979 – 1984 Kosygin State University of Russia (Technologies.
+              Design. Arts).
+            </p>
+            <p>
+              Since 1985 has been taking part in exhibitions, since 1987 began
+              to participate in foreign exhibitions.
+            </p>
+            <p>
+              Since 1991 member of Moscow Artists Union, member of Russian
+              Artists Union.
+            </p>
+          </section>
+          <section>
+            <h2 id="exhibitions">Exhibitions &amp; Residencies</h2>
+            <ul>
+              <li>2024 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
+              <li>2023 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
+              <li>
+                2022 – exhibition "Open Art Posa", Kloster Posa, Zeitz, Germany.
+              </li>
+              <li>2022 – resident of "Atelierhaus Zeitz", Zeitz, Germany.</li>
+              <li>
+                2022 – exhibition "Programm für…", Atelierhaus, Zeitz, Germany.
+              </li>
+              <li>
+                2019 – resident of “Cité internationale des arts”, Paris, France
+                (projects “Remembering the seventies”, “Je suis social”).
+              </li>
+              <li>
+                2018 – participant of the festival “Les Traversées du Marais”
+                (project “Sinai stars”).
+              </li>
+              <li>
+                2018 – resident of “Cité internationale des arts”, Paris, France
+                (projects “La Danse”, “The Endlove”).
+              </li>
+              <li>
+                2014 – solo exhibition “Why does it exist?”, residence “Nauart”
+                Barcelona, Spain.
+              </li>
+              <li>2014 – resident of “Nauart” Barcelona, Spain.</li>
+              <li>
+                2014 – exhibition “Four Positions of Contemporary Painting”,
+                gallery “Art Place Berlin”, Berlin, Germany.
+              </li>
+              <li>
+                2013 – solo exhibition, gallery “Na Kashirke”, Moscow, Russia.
+              </li>
+            </ul>
+            <details>
+              <summary>Earlier</summary>
+              <ul>
+                <li>
+                  2012 – solo exhibition, museum “Tsaritsyno”, Moscow, Russia.
+                </li>
+                <li>2010 – exhibition, gallery “Smend”, Cologne, Germany.</li>
+                <li>
+                  2009 – solo exhibition, gallery “Etienne Dewulf”, Ghent,
+                  Belgium.
+                </li>
+                <li>2008 – exhibition, gallery “CART”, Moscow, Russia.</li>
+                <li>
+                  2005 – solo exhibition “Ambiguous situation”, gallery
+                  “Kuznetsky Most”, Moscow, Russia.
+                </li>
+                <li>
+                  1998 – exhibition “in absentia - in corpore”, gallery “Zamek
+                  Książ”, Wałbrzych, Poland.
+                </li>
+                <li>
+                  1997 – exhibition, State Tretyakov Gallery, Moscow, Russia.
+                </li>
+                <li>1993 – exhibition, gallery “Habiart”, Delhi, India.</li>
+                <li>1992 – biennale “Deuxième”, Belgium.</li>
+                <li>
+                  1991 – exhibition, gallery “David Harrington”, London,
+                  England.
+                </li>
+                <li>1990 – exhibition, gallery “F-15”, Moss, Norway.</li>
+              </ul>
+            </details>
+          </section>
+          <section>
+            <h2 id="awards">Awards</h2>
+            <ul>
+              <li>
+                2014 – medal for merit in creative activities, Moscow Artists
+                Union.
+              </li>
+              <li>2007 – Diploma of the Russian Academy of Arts.</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="collections">Collections</h2>
+            <ul>
+              <li>Moscow Museum of Modern Art</li>
+              <li>“Bank of America” collection</li>
+              <li>Tsaritsyno Museum, Moscow</li>
+              <li>Wałbrzych Museum, Poland</li>
+              <li>Russian Decorative Art Museum, Moscow</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="teaching">Teaching Position</h2>
+            <p>
+              1997–1999 Kosygin State University of Russia (Technologies.
+              Design. Arts), assistant professor, composition.
+            </p>
+          </section>
+          <section>
+            <h2 id="trips">Creative Trips</h2>
+            <ul>
+              <li>2022 – Egypt, Cairo</li>
+              <li>2020 – Israel, Jerusalem</li>
+              <li>2019 – Greece, Athens</li>
+              <li>2018 – Egypt, Port Said, Ismailia, Luxor</li>
+              <li>2017 – Italy, Venice</li>
+              <li>2016 – Italy, Rome, Florence, Milan</li>
+              <li>2015 – Germany, Berlin</li>
+              <li>2014 – France, Paris</li>
+              <li>2013 – Myanmar, Bagan</li>
+              <li>2012 – India, Hampi</li>
+              <li>2009 – Holland, Amsterdam</li>
+              <li>2008 – Spain, Madrid</li>
+              <li>1998 – Poland, Wroclaw</li>
+              <li>1993 – India, the Himalayas</li>
+              <li>1992 – India, the Himalayas</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="contact">Contact</h2>
+            <p>
+              <a
+                class="email"
+                data-user="alexander-kosyak-art"
+                data-domain="yandex.ru"
+              ></a>
+              <button class="copy-email" type="button">Copy email</button>
+            </p>
+            <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
+          </section>
+        </main>
+      </div>
+
+      <div data-lang="ru">
+        <header>
+          <div class="intro-grid">
+            <div class="intro-info">
+              <h1>Александр Косяк</h1>
+              <p>
+                Александр Косяк родился 8 декабря 1957 года в России. Художник,
+                участник выставок с 1985 года, член Московского союза
+                художников.
+              </p>
+              <p>
+                Коллекции: ММОМА; Bank of America; Царицыно · Резиденции: Cité
+                internationale des arts; Atelierhaus Zeitz · Награды: медаль
+                Московского союза художников; диплом Российской академии
+                художеств.
+              </p>
+            </div>
+          </div>
+        </header>
+        <main>
+          <section>
+            <h2 id="bio">Биография</h2>
+            <p>Родился 08.12.1957, Россия.</p>
+            <p>1970 – 1974 Школа искусств, г. Пятигорск.</p>
+            <p>
+              1979 – 1984 Российский государственный университет им. А.Н.
+              Косыгина (технологии, дизайн, искусство).
+            </p>
+            <p>
+              С 1985 года участвует в выставках, с 1987 года начал участвовать в
+              зарубежных выставках.
+            </p>
+            <p>
+              С 1991 года член Московского союза художников, член Союза
+              художников России.
+            </p>
+          </section>
+          <section>
+            <h2 id="exhibitions">Выставки и резиденции</h2>
+            <ul>
+              <li>2024 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
+              <li>2023 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
+              <li>
+                2022 – выставка «Open Art Posa», Kloster Posa, Цайц, Германия.
+              </li>
+              <li>2022 – резидент «Atelierhaus Zeitz», Цайц, Германия.</li>
+              <li>
+                2022 – выставка «Programm für…», Atelierhaus, Цайц, Германия.
+              </li>
+              <li>
+                2019 – резидент «Cité internationale des arts», Париж, Франция
+                (проекты «Remembering the seventies», «Je suis social»).
+              </li>
+              <li>
+                2018 – участник фестиваля «Les Traversées du Marais» (проект
+                «Sinai stars»).
+              </li>
+              <li>
+                2018 – резидент «Cité internationale des arts», Париж, Франция
+                (проекты «La Danse», «The Endlove»).
+              </li>
+              <li>
+                2014 – персональная выставка «Why does it exist?», резиденция
+                «Nauart» Барселона, Испания.
+              </li>
+              <li>2014 – резидент «Nauart» Барселона, Испания.</li>
+              <li>
+                2014 – выставка «Four Positions of Contemporary Painting»,
+                галерея «Art Place Berlin», Берлин, Германия.
+              </li>
+              <li>
+                2013 – персональная выставка, галерея «На Каширке», Москва,
+                Россия.
+              </li>
+            </ul>
+            <details>
+              <summary>Ранее</summary>
+              <ul>
+                <li>
+                  2012 – персональная выставка, музей «Царицыно», Москва,
+                  Россия.
+                </li>
+                <li>2010 – выставка, галерея «Smend», Кёльн, Германия.</li>
+                <li>
+                  2009 – персональная выставка, галерея «Etienne Dewulf», Гент,
+                  Бельгия.
+                </li>
+                <li>2008 – выставка, галерея «CART», Москва, Россия.</li>
+                <li>
+                  2005 – персональная выставка «Ambiguous situation», галерея
+                  «Кузнецкий Мост», Москва, Россия.
+                </li>
+                <li>
+                  1998 – выставка «in absentia - in corpore», галерея «Zamek
+                  Ksiaz», Вальбжих, Польша.
+                </li>
+                <li>
+                  1997 – выставка, Государственная Третьяковская галерея,
+                  Москва, Россия.
+                </li>
+                <li>1993 – выставка, галерея «Habiart», Дели, Индия.</li>
+                <li>1992 – биеннале «Deuxien», Бельгия.</li>
+                <li>
+                  1991 – выставка, галерея «David Harrington», Лондон, Англия.
+                </li>
+                <li>1990 – выставка, галерея «F-15», Мосс, Норвегия.</li>
+              </ul>
+            </details>
+          </section>
+          <section>
+            <h2 id="awards">Награды</h2>
+            <ul>
+              <li>
+                2014 – медаль за заслуги в творческой деятельности, Московский
+                союз художников.
+              </li>
+              <li>2007 – диплом Российской академии художеств.</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="collections">Коллекции</h2>
+            <ul>
+              <li>Московский музей современного искусства</li>
+              <li>Коллекция «Bank of America»</li>
+              <li>Музей «Царицыно», Москва</li>
+              <li>Музей Вальбжиха, Польша</li>
+              <li>Музей декоративного искусства, Москва</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="teaching">Преподавание</h2>
+            <p>
+              1997–1999 Российский государственный университет им. А.Н. Косыгина
+              (технологии, дизайн, искусство), ассистент-профессор, композиция.
+            </p>
+          </section>
+          <section>
+            <h2 id="trips">Творческие поездки</h2>
+            <ul>
+              <li>2022 – Египет, Каир</li>
+              <li>2020 – Израиль, Иерусалим</li>
+              <li>2019 – Греция, Афины</li>
+              <li>2018 – Египет, Порт-Саид, Исмаилия, Луксор</li>
+              <li>2017 – Италия, Венеция</li>
+              <li>2016 – Италия, Рим, Флоренция, Милан</li>
+              <li>2015 – Германия, Берлин</li>
+              <li>2014 – Франция, Париж</li>
+              <li>2013 – Мьянма, Баган</li>
+              <li>2012 – Индия, Хампи</li>
+              <li>2009 – Голландия, Амстердам</li>
+              <li>2008 – Испания, Мадрид</li>
+              <li>1998 – Польша, Вроцлав</li>
+              <li>1993 – Индия, Гималаи</li>
+              <li>1992 – Индия, Гималаи</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="contact">Контакты</h2>
+            <p>
+              <a
+                class="email"
+                data-user="alexander-kosyak-art"
+                data-domain="yandex.ru"
+              ></a>
+              <button class="copy-email" type="button">
+                Скопировать email
+              </button>
+            </p>
+            <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
+          </section>
+        </main>
+      </div>
+
+      <div data-lang="de">
+        <header>
+          <div class="intro-grid">
+            <div class="intro-info">
+              <h1>Alexander Kosyak</h1>
+              <p>
+                Alexander Kosyak wurde am 08.12.1957 in Russland geboren.
+                Künstler, seit 1985 an Ausstellungen beteiligt, Mitglied des
+                Moskauer Künstlerverbands.
+              </p>
+              <p>
+                Sammlungen: MMOMA; Bank of America; Tsaritsyno · Residenzen:
+                Cité internationale des arts; Atelierhaus Zeitz ·
+                Auszeichnungen: Medaille des Moskauer Künstlerverbands; Diplom
+                der Russischen Akademie der Künste.
+              </p>
+            </div>
+          </div>
+        </header>
+        <main>
+          <section>
+            <h2 id="bio">Biografie</h2>
+            <p>Geboren am 08.12.1957, Russland.</p>
+            <p>1970 – 1974 Kunstschule, Stadt Pjatigorsk.</p>
+            <p>
+              1979 – 1984 Staatliche Technologische Universität Russlands namens
+              A. N. Kosygin (Technologien. Design. Kunst).
+            </p>
+            <p>
+              Seit 1985 nimmt er an Ausstellungen teil, seit 1987 an
+              Ausstellungen im Ausland.
+            </p>
+            <p>
+              Seit 1991 Mitglied des Moskauer Künstlerverbands, Mitglied des
+              Künstlerverbands Russlands.
+            </p>
+          </section>
+          <section>
+            <h2 id="exhibitions">Ausstellungen &amp; Residenzen</h2>
+            <ul>
+              <li>
+                2024 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.
+              </li>
+              <li>
+                2023 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.
+              </li>
+              <li>
+                2022 – Ausstellung „Open Art Posa“, Kloster Posa, Zeitz,
+                Deutschland.
+              </li>
+              <li>
+                2022 – Resident des „Atelierhaus Zeitz“, Zeitz, Deutschland.
+              </li>
+              <li>
+                2022 – Ausstellung „Programm für…“, Atelierhaus, Zeitz,
+                Deutschland.
+              </li>
+              <li>
+                2019 – Resident der „Cité internationale des arts“, Paris,
+                Frankreich (Projekte „Remembering the seventies“, „Je suis
+                social“).
+              </li>
+              <li>
+                2018 – Teilnehmer des Festivals „Les Traversées du Marais“
+                (Projekt „Sinai stars“).
+              </li>
+              <li>
+                2018 – Resident der „Cité internationale des arts“, Paris,
+                Frankreich (Projekte „La Danse“, „The Endlove“).
+              </li>
+              <li>
+                2014 – Einzelausstellung „Why does it exist?“, Residenz „Nauart“
+                Barcelona, Spanien.
+              </li>
+              <li>2014 – Resident „Nauart“ Barcelona, Spanien.</li>
+              <li>
+                2014 – Ausstellung „Four Positions of Contemporary Painting“,
+                Galerie „Art Place Berlin“, Berlin, Deutschland.
+              </li>
+              <li>
+                2013 – Einzelausstellung, Galerie „Na Kashirke“, Moskau,
+                Russland.
+              </li>
+            </ul>
+            <details>
+              <summary>Früher</summary>
+              <ul>
+                <li>
+                  2012 – Einzelausstellung, Museum „Tsaritsyno“, Moskau,
+                  Russland.
+                </li>
+                <li>2010 – Ausstellung, Galerie „Smend“, Köln, Deutschland.</li>
+                <li>
+                  2009 – Einzelausstellung, Galerie „Etienne Dewulf“, Gent,
+                  Belgien.
+                </li>
+                <li>2008 – Ausstellung, Galerie „CART“, Moskau, Russland.</li>
+                <li>
+                  2005 – Einzelausstellung „Ambiguous situation“, Galerie
+                  „Kuznetsky Most“, Moskau, Russland.
+                </li>
+                <li>
+                  1998 – Ausstellung „in absentia - in corpore“, Galerie „Zamek
+                  Książ“, Wałbrzych, Polen.
+                </li>
+                <li>
+                  1997 – Ausstellung, Staatliche Tretjakow-Galerie, Moskau,
+                  Russland.
+                </li>
+                <li>1993 – Ausstellung, Galerie „Habiart“, Delhi, Indien.</li>
+                <li>1992 – Biennale „Deuxième“, Belgien.</li>
+                <li>
+                  1991 – Ausstellung, Galerie „David Harrington“, London,
+                  England.
+                </li>
+                <li>1990 – Ausstellung, Galerie „F-15“, Moss, Norwegen.</li>
+              </ul>
+            </details>
+          </section>
+          <section>
+            <h2 id="awards">Auszeichnungen</h2>
+            <ul>
+              <li>
+                2014 – Medaille für Verdienste in der künstlerischen Tätigkeit,
+                Moskauer Künstlerverband.
+              </li>
+              <li>2007 – Diplom der Russischen Akademie der Künste.</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="collections">Sammlungen</h2>
+            <ul>
+              <li>Museum für zeitgenössische Kunst Moskau</li>
+              <li>Sammlung „Bank of America“</li>
+              <li>Museum „Tsaritsyno“, Moskau</li>
+              <li>Museum Wałbrzych, Polen</li>
+              <li>Russisches Museum für dekorative Kunst, Moskau</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="teaching">Lehrtätigkeit</h2>
+            <p>
+              1997–1999 Staatliche Technologische Universität Russlands namens
+              A. N. Kosygin (Technologien. Design. Kunst), Assistenzprofessor,
+              Komposition.
+            </p>
+          </section>
+          <section>
+            <h2 id="trips">Kreativreisen</h2>
+            <ul>
+              <li>2022 – Ägypten, Kairo</li>
+              <li>2020 – Israel, Jerusalem</li>
+              <li>2019 – Griechenland, Athen</li>
+              <li>2018 – Ägypten, Port Said, Ismailia, Luxor</li>
+              <li>2017 – Italien, Venedig</li>
+              <li>2016 – Italien, Rom, Florenz, Mailand</li>
+              <li>2015 – Deutschland, Berlin</li>
+              <li>2014 – Frankreich, Paris</li>
+              <li>2013 – Myanmar, Bagan</li>
+              <li>2012 – Indien, Hampi</li>
+              <li>2009 – Holland, Amsterdam</li>
+              <li>2008 – Spanien, Madrid</li>
+              <li>1998 – Polen, Wroclaw</li>
+              <li>1993 – Indien, Himalaya</li>
+              <li>1992 – Indien, Himalaya</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="contact">Kontakt</h2>
+            <p>
+              <a
+                class="email"
+                data-user="alexander-kosyak-art"
+                data-domain="yandex.ru"
+              ></a>
+              <button class="copy-email" type="button">E-Mail kopieren</button>
+            </p>
+            <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
+          </section>
+        </main>
+      </div>
+
+      <div data-lang="fr">
+        <header>
+          <div class="intro-grid">
+            <div class="intro-info">
+              <h1>Alexander Kosyak</h1>
+              <p>
+                Alexander Kosyak est né le 08.12.1957 en Russie. Artiste,
+                participant aux expositions depuis 1985, membre de l'Union des
+                artistes de Moscou.
+              </p>
+              <p>
+                Collections : MMOMA; Bank of America; Tsaritsyno · Résidences :
+                Cité internationale des arts; Atelierhaus Zeitz · Récompenses :
+                médaille de l'Union des artistes de Moscou; diplôme de
+                l'Académie des arts de Russie.
+              </p>
+            </div>
+          </div>
+        </header>
+        <main>
+          <section>
+            <h2 id="bio">Biographie</h2>
+            <p>Né le 08.12.1957, Russie.</p>
+            <p>1970–1974 École des arts, ville de Piatigorsk.</p>
+            <p>
+              1979–1984 Université d'État Kosyguine de Russie (Technologies.
+              Design. Arts).
+            </p>
+            <p>
+              Depuis 1985 participe à des expositions, depuis 1987 participe à
+              des expositions à l'étranger.
+            </p>
+            <p>
+              Depuis 1991 membre de l'Union des artistes de Moscou, membre de
+              l'Union des artistes de Russie.
+            </p>
+          </section>
+          <section>
+            <h2 id="exhibitions">Expositions &amp; Résidences</h2>
+            <ul>
+              <li>
+                2024 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.
+              </li>
+              <li>
+                2023 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.
+              </li>
+              <li>
+                2022 – exposition « Open Art Posa », Kloster Posa, Zeitz,
+                Allemagne.
+              </li>
+              <li>
+                2022 – résident de l'« Atelierhaus Zeitz », Zeitz, Allemagne.
+              </li>
+              <li>
+                2022 – exposition « Programm für… », Atelierhaus, Zeitz,
+                Allemagne.
+              </li>
+              <li>
+                2019 – résident de la « Cité internationale des arts », Paris,
+                France (projets « Remembering the seventies », « Je suis social
+                »).
+              </li>
+              <li>
+                2018 – participant du festival « Les Traversées du Marais »
+                (projet « Sinai stars »).
+              </li>
+              <li>
+                2018 – résident de la « Cité internationale des arts », Paris,
+                France (projets « La Danse », « The Endlove »).
+              </li>
+              <li>
+                2014 – exposition personnelle « Why does it exist? », résidence
+                « Nauart », Barcelone, Espagne.
+              </li>
+              <li>2014 – résident de « Nauart », Barcelone, Espagne.</li>
+              <li>
+                2014 – exposition « Four Positions of Contemporary Painting »,
+                galerie « Art Place Berlin », Berlin, Allemagne.
+              </li>
+              <li>
+                2013 – exposition personnelle, galerie « Na Kashirke », Moscou,
+                Russie.
+              </li>
+            </ul>
+            <details>
+              <summary>Plus tôt</summary>
+              <ul>
+                <li>
+                  2012 – exposition personnelle, musée « Tsaritsino », Moscou,
+                  Russie.
+                </li>
+                <li>
+                  2010 – exposition, galerie « Smend », Cologne, Allemagne.
+                </li>
+                <li>
+                  2009 – exposition personnelle, galerie « Etienne Dewulf »,
+                  Gand, Belgique.
+                </li>
+                <li>2008 – exposition, galerie « CART », Moscou, Russie.</li>
+                <li>
+                  2005 – exposition personnelle « Ambiguous situation », galerie
+                  « Kuznetsky Most », Moscou, Russie.
+                </li>
+                <li>
+                  1998 – exposition « in absentia - in corpore », galerie «
+                  Zamek Książ », Wałbrzych, Pologne.
+                </li>
+                <li>
+                  1997 – exposition, Galerie d’État Tretiakov, Moscou, Russie.
+                </li>
+                <li>1993 – exposition, galerie « Habiart », Delhi, Inde.</li>
+                <li>1992 – biennale « Deuxième », Belgique.</li>
+                <li>
+                  1991 – exposition, galerie « David Harrington », Londres,
+                  Angleterre.
+                </li>
+                <li>1990 – exposition, galerie « F-15 », Moss, Norvège.</li>
+              </ul>
+            </details>
+          </section>
+          <section>
+            <h2 id="awards">Récompenses</h2>
+            <ul>
+              <li>
+                2014 – médaille du mérite artistique, Union des artistes de
+                Moscou.
+              </li>
+              <li>2007 – Diplôme de l’Académie des Arts de Russie.</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="collections">Collections</h2>
+            <ul>
+              <li>Musée d'art moderne de Moscou</li>
+              <li>Collection « Bank of America »</li>
+              <li>Musée Tsaritsyno, Moscou</li>
+              <li>Musée de Wałbrzych, Pologne</li>
+              <li>Musée d'art décoratif de Russie, Moscou</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="teaching">Enseignement</h2>
+            <p>
+              1997–1999 Université d'État Kosyguine de Russie (Technologies.
+              Design. Arts), professeur adjoint, composition.
+            </p>
+          </section>
+          <section>
+            <h2 id="trips">Voyages créatifs</h2>
+            <ul>
+              <li>2022 – Égypte, Le Caire</li>
+              <li>2020 – Israël, Jérusalem</li>
+              <li>2019 – Grèce, Athènes</li>
+              <li>2018 – Égypte, Port-Saïd, Ismaïlia, Louxor</li>
+              <li>2017 – Italie, Venise</li>
+              <li>2016 – Italie, Rome, Florence, Milan</li>
+              <li>2015 – Allemagne, Berlin</li>
+              <li>2014 – France, Paris</li>
+              <li>2013 – Myanmar, Bagan</li>
+              <li>2012 – Inde, Hampi</li>
+              <li>2009 – Pays-Bas, Amsterdam</li>
+              <li>2008 – Espagne, Madrid</li>
+              <li>1998 – Pologne, Wrocław</li>
+              <li>1993 – Inde, Himalaya</li>
+              <li>1992 – Inde, Himalaya</li>
+            </ul>
+          </section>
+          <section>
+            <h2 id="contact">Contact</h2>
+            <p>
+              <a
+                class="email"
+                data-user="alexander-kosyak-art"
+                data-domain="yandex.ru"
+              ></a>
+              <button class="copy-email" type="button">Copier l’email</button>
+            </p>
+            <p><a href="tel:+79032388355">+7 903 238 8355</a></p>
+          </section>
+        </main>
+      </div>
+    </div>
+    <footer>
+      <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
+    </footer>
+    <script>
+      const langButtons = document.querySelectorAll(".lang-switcher button");
+      const blocks = document.querySelectorAll("[data-lang]");
+      const blocksContainer = document.getElementById("lang-blocks");
+      function showLang(lang) {
+        blocks.forEach((block) => {
+          const show = block.dataset.lang === lang;
+          block.style.display = show ? "block" : "none";
+          if (show) blocksContainer.prepend(block);
+        });
+        document.documentElement.lang = lang;
+        localStorage.setItem("lang", lang);
+        langButtons.forEach((btn) =>
+          btn.classList.toggle("active", btn.dataset.setlang === lang),
+        );
+      }
+      langButtons.forEach((btn) =>
+        btn.addEventListener("click", () => showLang(btn.dataset.setlang)),
+      );
+      showLang(localStorage.getItem("lang") || "en");
+
+      document.querySelectorAll(".email").forEach((link) => {
+        const email = `${link.dataset.user}@${link.dataset.domain}`;
+        link.href = `mailto:${email}`;
+        link.textContent = email;
+        const btn = link.nextElementSibling;
+        if (btn && btn.classList.contains("copy-email")) {
+          btn.addEventListener("click", () => {
+            navigator.clipboard.writeText(email);
+          });
+        }
+      });
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,44 +1,86 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="color-scheme" content="light dark"/>
-  <title>Alexander Kosyak Art Studio</title>
-  <meta name="description" content="Artist Alexander Kosyak. Exhibitions since 1985. Member of Moscow Artists Union."/>
-  <meta property="og:title" content="Alexander Kosyak – Art Project"/>
-  <meta property="og:description" content="Artist. Exhibitions since 1985. Member of Moscow Artists Union."/>
-  <meta property="og:image" content="images/ak1.jpg"/>
-  <link rel="preconnect" href="https://fonts.googleapis.com"/>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="style.css"/>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    "name": "Alexander Kosyak",
-    "birthDate": "1957-12-08",
-    "memberOf": "Moscow Artists Union",
-    "award": "Russian Academy of Arts diploma"
-  }
-  </script>
-</head>
-<body>
-  <nav class="top-nav">
-    <a href="index.html">Home</a>
-    <a href="biography.html">Biography</a>
-    <a href="last-works.html">Last Works</a>
-    <a href="contact.html">Contact</a>
-  </nav>
-  <main class="gallery">
-    <img src="images/ak1.jpg" alt="Alexander Kosyak in his studio"/>
-    <img src="images/ak2.jpg" alt="Studio view"/>
-    <img src="images/ak3.jpg" alt="Studio view"/>
-    <img src="images/ak4.jpg" alt="Graphic artwork"/>
-  </main>
-  <footer>
-    <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
-  </footer>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Alexander Kosyak Art Studio</title>
+    <meta
+      name="description"
+      content="Artist Alexander Kosyak. Exhibitions since 1985. Member of Moscow Artists Union."
+    />
+    <meta property="og:title" content="Alexander Kosyak – Art Project" />
+    <meta
+      property="og:description"
+      content="Artist. Exhibitions since 1985. Member of Moscow Artists Union."
+    />
+    <meta property="og:image" content="images/ak1.jpg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Alexander Kosyak",
+        "birthDate": "1957-12-08",
+        "memberOf": "Moscow Artists Union",
+        "award": "Russian Academy of Arts diploma"
+      }
+    </script>
+  </head>
+  <body>
+    <nav class="top-nav">
+      <a href="index.html">Home</a>
+      <a href="biography.html">Biography</a>
+      <a href="last-works.html">Last Works</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <main class="gallery">
+      <figure class="artwork">
+        <img src="images/ak1.jpg" alt="ink on paper, 100 × 130 cm" />
+        <figcaption>ink on paper,<br />100 × 130 cm</figcaption>
+      </figure>
+      <figure class="artwork">
+        <img
+          src="images/ak2.jpg"
+          alt='"Moonlight" acrylic on canvas, 220 × 140 cm'
+        />
+        <figcaption>
+          "Moonlight"<br />acrylic on canvas<br />220 × 140 cm
+        </figcaption>
+      </figure>
+      <figure class="artwork">
+        <img
+          src="images/ak3.jpg"
+          alt='"Prophets" (fragment) acrylic on canvas'
+        />
+        <figcaption>"Prophets" (fragment)<br />acrylic on canvas</figcaption>
+      </figure>
+      <figure class="artwork">
+        <img
+          src="images/ak4.jpg"
+          alt='"At sunset" acrylic on canvas, 180 × 120 cm'
+        />
+        <figcaption>
+          "At sunset"<br />acrylic on canvas<br />180 × 120 cm
+        </figcaption>
+      </figure>
+    </main>
+    <footer>
+      <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
+    </footer>
+    <script>
+      document.querySelectorAll(".gallery .artwork").forEach((fig) => {
+        fig.addEventListener("click", () => {
+          const caption = fig.querySelector("figcaption");
+          caption.classList.toggle("visible");
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -18,12 +18,14 @@ html {
 
 body {
   margin: 0;
-  font-family: 'Montserrat', sans-serif;
+  font-family: "Montserrat", sans-serif;
   line-height: 1.6;
   font-size: clamp(1rem, 0.9rem + 0.3vw, 1.1rem);
   background: var(--bg-color);
   color: var(--text-color);
-  transition: background 0.3s ease, color 0.3s ease;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
   padding-top: var(--toolbar-height);
 }
 
@@ -195,3 +197,23 @@ a:hover {
   display: block;
 }
 
+.gallery .artwork {
+  position: relative;
+  cursor: pointer;
+}
+
+.gallery .artwork figcaption {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.gallery .artwork figcaption.visible {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- show artwork title and dimensions when clicking images on the home page
- simplify biography introduction with consistent plain formatting across languages

## Testing
- `npx prettier --check index.html biography.html style.css`

------
https://chatgpt.com/codex/tasks/task_e_68a915ff73248328bafd125f61868c23