### PR TITLE
Add recent works gallery with clickable captions

### DIFF
--- a/last-works.html
+++ b/last-works.html
@@ -23,14 +23,107 @@
   </nav>
   <main>
     <h1>Last Works</h1>
-    <ul>
-      <li>Placeholder work 1</li>
-      <li>Placeholder work 2</li>
-      <li>Placeholder work 3</li>
-    </ul>
+
+    <section>
+      <h2 class="period-title">2023–2025</h2>
+      <div class="gallery">
+        <figure class="artwork">
+          <img src="images/recent/1/photo_2025-08-24_23-55-57.jpg" alt='"Manul walk" acrylic on canvas, ink, 500 × 95 cm'/>
+          <figcaption>"Manul walk"<br/>acrylic on canvas, ink<br/>500 × 95 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/1/photo_2025-08-24_23-55-59.jpg" alt='"Moonlight" acrylic on canvas, 220 × 140 cm'/>
+          <figcaption>"Moonlight"<br/>acrylic on canvas<br/>220 × 140 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/1/photo_2025-08-24_23-56-00.jpg" alt='"Dreamer" acrylic on canvas, 130 × 220 cm'/>
+          <figcaption>"Dreamer"<br/>acrylic on canvas<br/>130 × 220 cm</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="period-title">2020–2023</h2>
+      <div class="gallery">
+        <figure class="artwork">
+          <img src="images/recent/2/photo_2025-08-24_23-56-05.jpg" alt='"Sunrise" acrylic on canvas, 180 × 300 cm'/>
+          <figcaption>"Sunrise"<br/>acrylic on canvas<br/>180 × 300 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/2/photo_2025-08-24_23-56-06.jpg" alt='"Prophets" acrylic on canvas, 180 × 300 cm'/>
+          <figcaption>"Prophets"<br/>acrylic on canvas<br/>180 × 300 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/2/photo_2025-08-24_23-56-07.jpg" alt='"Civilization 1" acrylic on canvas, 120 × 120 cm'/>
+          <figcaption>"Civilization 1"<br/>acrylic on canvas<br/>120 × 120 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/2/photo_2025-08-24_23-56-08.jpg" alt='"Civilization 2" acrylic on canvas, 140 × 110 cm'/>
+          <figcaption>"Civilization 2"<br/>acrylic on canvas<br/>140 × 110 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/2/photo_2025-08-24_23-56-09.jpg" alt='"Apostle" acrylic on canvas, 120 × 120 cm'/>
+          <figcaption>"Apostle"<br/>acrylic on canvas<br/>120 × 120 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/2/photo_2025-08-24_23-56-10.jpg" alt='"Love letter" acrylic on canvas, 180 × 120 cm'/>
+          <figcaption>"Love letter"<br/>acrylic on canvas<br/>180 × 120 cm</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="period-title">2023–2025</h2>
+      <div class="gallery">
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-11.jpg" alt='"Poet" Ink on paper, pen, 40 × 20 cm'/>
+          <figcaption>"Poet"<br/>Ink on paper, pen<br/>40 × 20 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-12.jpg" alt='"Doubts" Ink on paper, pen, 100 × 130 cm'/>
+          <figcaption>"Doubts"<br/>Ink on paper, pen<br/>100 × 130 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-13.jpg" alt='"Meeting" Ink on paper, pen, 30 × 20 cm'/>
+          <figcaption>"Meeting"<br/>Ink on paper, pen<br/>30 × 20 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-14.jpg" alt='"Flower" Ink on paper, pen, 30 × 25 cm'/>
+          <figcaption>"Flower"<br/>Ink on paper, pen<br/>30 × 25 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-15.jpg" alt='"Watcher" Ink on paper, pen, 40 × 20 cm'/>
+          <figcaption>"Watcher"<br/>Ink on paper, pen<br/>40 × 20 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-16.jpg" alt='"Rainbow" Ink on paper, pen, 30 × 20 cm'/>
+          <figcaption>"Rainbow"<br/>Ink on paper, pen<br/>30 × 20 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-17.jpg" alt='"Parachutist" Ink on paper, pen, 90 × 50 cm'/>
+          <figcaption>"Parachutist"<br/>Ink on paper, pen<br/>90 × 50 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-18.jpg" alt='"Dawn" Ink on paper, pen, 30 × 40 cm'/>
+          <figcaption>"Dawn"<br/>Ink on paper, pen<br/>30 × 40 cm</figcaption>
+        </figure>
+        <figure class="artwork">
+          <img src="images/recent/3/photo_2025-08-24_23-56-19.jpg" alt='"Windy day" Ink on paper, pen, 25 × 35 cm'/>
+          <figcaption>"Windy day"<br/>Ink on paper, pen<br/>25 × 35 cm</figcaption>
+        </figure>
+      </div>
+    </section>
   </main>
   <footer>
     <p>© Alexander Kosyak Art Studio. All rights reserved.</p>
   </footer>
+  <script>
+    document.querySelectorAll(".gallery .artwork").forEach((fig) => {
+      fig.addEventListener("click", () => {
+        const caption = fig.querySelector("figcaption");
+        caption.classList.toggle("visible");
+      });
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -94,6 +94,10 @@ h2 {
   font-weight: 600;
 }
 
+.period-title {
+  font-weight: 400;
+}
+
 ul {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- Display recent works in three period sections with clickable captions revealing title, medium, and size.
- Style period headings with normal font weight so numbers appear regular.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7f764eb48328b34b0f1d6ef04af6