### PR TITLE
Fix language switcher alignment

### DIFF
--- a/biography.html
+++ b/biography.html
@@ -42,13 +42,13 @@
       <a href="biography.html">Biography</a>
       <a href="last-works.html">Last Works</a>
       <a href="contact.html">Contact</a>
+      <div class="lang-switcher" role="group" aria-label="Language switcher">
+        <button data-setlang="en">EN</button>
+        <button data-setlang="ru">RU</button>
+        <button data-setlang="de">DE</button>
+        <button data-setlang="fr">FR</button>
+      </div>
     </nav>
-    <div class="lang-switcher" role="group" aria-label="Language switcher">
-      <button data-setlang="en">EN</button>
-      <button data-setlang="ru">RU</button>
-      <button data-setlang="de">DE</button>
-      <button data-setlang="fr">FR</button>
-    </div>
     <div id="lang-blocks">
       <div data-lang="en">
         <header class="title-with-photo bio-header">

--- a/style.css
+++ b/style.css
@@ -125,6 +125,15 @@ a:hover {
   color: var(--accent-color);
 }
 
+.lang-switcher {
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 0.25rem;
+}
+
 .lang-switcher button,
 #theme-toggle {
   font: inherit;


### PR DESCRIPTION
## Summary
- Move language switcher inside top nav
- Position language switcher at the nav's top-right without affecting centered links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6fba8a6c832883edafd53b92946e