### PR TITLE
fix: responsive language switcher layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -134,6 +134,16 @@ a:hover {
   gap: 0.25rem;
 }
 
+@media (max-width: 600px) {
+  .lang-switcher {
+    position: static;
+    transform: none;
+    width: 100%;
+    justify-content: center;
+    margin-top: 0.5rem;
+  }
+}
+
 .lang-switcher button,
 #theme-toggle {
   font: inherit;


### PR DESCRIPTION
## Summary
- Prevent language buttons from overlapping nav on mobile by adding responsive styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8d8b533c8328ab92475d4c15446a